### PR TITLE
UI freeze debug

### DIFF
--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
@@ -68,7 +68,6 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
     private View navigationDrawerHeader;
 
     private boolean blockRequestPermissions;
-    private boolean scanning;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -353,14 +352,6 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
             return true;
         }
         return false;
-    }
-
-    public boolean isNotScanning() {
-        return !scanning;
-    }
-
-    public void setScanning(boolean scanning) {
-        this.scanning = scanning;
     }
 
     private void showChangelog() {


### PR DESCRIPTION
Bug: main UI freeze after discog update(songs added/removed after scan, or metadata modified).

Likely to happen with:
- songs added to OS, possibly not yet imported to Discog
- while songs being played 
- and app not in foreground

Note that while the main UI freezes, the notification continues to update till the end of the playing song. When it gets to the next song, notification UI is not updated but the next songs plays.