### PR TITLE
Upgrade material cab

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 33
     namespace 'com.poupa.vinylmusicplayer'
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 29
         renderscriptTargetApi 29
 
@@ -113,7 +113,7 @@ dependencies {
     // TODO Upgrade to the Kotlin version - the Java one is not maintained
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
-    implementation 'com.afollestad:material-cab:0.1.12'
+    implementation 'com.afollestad:material-cab:2.0.1'
 
     implementation 'com.github.ksoichiro:android-observablescrollview:1.6.0'
     implementation 'me.zhanghai.android.materialprogressbar:library:1.6.1'

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
@@ -149,11 +149,6 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
     }
 
     @Override
-    protected String getName(Playlist playlist) {
-        return playlist.name;
-    }
-
-    @Override
     protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Playlist> selection) {
         if (R.id.action_delete_playlist == menuItem.getItemId()) {
             for (int i = 0; i < selection.size(); i++) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/PlaylistAdapter.java
@@ -53,7 +53,7 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
     protected final AppCompatActivity activity;
     protected ArrayList<Playlist> dataSet;
 
-    public PlaylistAdapter(AppCompatActivity activity, ArrayList<Playlist> dataSet, @Nullable CabHolder cabHolder) {
+    public PlaylistAdapter(AppCompatActivity activity, ArrayList<Playlist> dataSet, @NonNull CabHolder cabHolder) {
         super(activity, cabHolder, R.menu.menu_playlists_selection);
         this.activity = activity;
         this.dataSet = dataSet;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/SongFileAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/SongFileAdapter.java
@@ -42,7 +42,8 @@ public class SongFileAdapter extends AbsMultiSelectAdapter<SongFileAdapter.ViewH
     @Nullable
     private final Callbacks callbacks;
 
-    public SongFileAdapter(@NonNull AppCompatActivity activity, @NonNull List<File> songFiles, @Nullable Callbacks callback, @Nullable CabHolder cabHolder) {
+    public SongFileAdapter(@NonNull AppCompatActivity activity, @NonNull List<File> songFiles,
+                           @Nullable Callbacks callback, @NonNull CabHolder cabHolder) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
         this.dataSet = songFiles;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/SongFileAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/SongFileAdapter.java
@@ -151,11 +151,6 @@ public class SongFileAdapter extends AbsMultiSelectAdapter<SongFileAdapter.ViewH
     }
 
     @Override
-    protected String getName(File object) {
-        return getFileTitle(object);
-    }
-
-    @Override
     protected void onMultipleItemAction(MenuItem menuItem, ArrayList<File> selection) {
         if (callbacks == null) return;
         callbacks.onMultipleItemAction(menuItem, selection);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/album/AlbumAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/album/AlbumAdapter.java
@@ -182,11 +182,6 @@ public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder,
     }
 
     @Override
-    protected String getName(Album album) {
-        return album.getTitle();
-    }
-
-    @Override
     protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Album> selection) {
         SongsMenuHelper.handleMenuClick(activity, getSongList(selection), menuItem.getItemId());
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/album/AlbumAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/album/AlbumAdapter.java
@@ -51,7 +51,8 @@ public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder,
 
     protected boolean usePalette;
 
-    public AlbumAdapter(@NonNull AppCompatActivity activity, ArrayList<Album> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public AlbumAdapter(@NonNull AppCompatActivity activity, ArrayList<Album> dataSet, @LayoutRes int itemLayoutRes,
+                        boolean usePalette, @NonNull CabHolder cabHolder) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
         this.dataSet = dataSet;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/album/HorizontalAlbumAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/album/HorizontalAlbumAdapter.java
@@ -28,7 +28,8 @@ import java.util.ArrayList;
  */
 public class HorizontalAlbumAdapter extends AlbumAdapter {
 
-    public HorizontalAlbumAdapter(@NonNull AppCompatActivity activity, ArrayList<Album> dataSet, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public HorizontalAlbumAdapter(@NonNull AppCompatActivity activity, ArrayList<Album> dataSet, boolean usePalette,
+                                  @NonNull CabHolder cabHolder) {
         super(activity, dataSet, HorizontalAdapterHelper.LAYOUT_RES, usePalette, cabHolder);
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/artist/ArtistAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/artist/ArtistAdapter.java
@@ -50,7 +50,8 @@ public class ArtistAdapter extends AbsMultiSelectAdapter<ArtistAdapter.ViewHolde
 
     protected boolean usePalette;
 
-    public ArtistAdapter(@NonNull AppCompatActivity activity, ArrayList<Artist> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public ArtistAdapter(@NonNull AppCompatActivity activity, ArrayList<Artist> dataSet, @LayoutRes int itemLayoutRes
+            , boolean usePalette, @NonNull CabHolder cabHolder) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
         this.dataSet = dataSet;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/artist/ArtistAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/artist/ArtistAdapter.java
@@ -171,11 +171,6 @@ public class ArtistAdapter extends AbsMultiSelectAdapter<ArtistAdapter.ViewHolde
     }
 
     @Override
-    protected String getName(Artist artist) {
-        return artist.getName();
-    }
-
-    @Override
     protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Artist> selection) {
         SongsMenuHelper.handleMenuClick(activity, getSongList(selection), menuItem.getItemId());
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
@@ -6,11 +6,14 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.annotation.MenuRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.poupa.vinylmusicplayer.R;
+import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsThemeActivity;
 import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
@@ -20,17 +23,19 @@ import java.util.ArrayList;
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
-public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, I> extends RecyclerView.Adapter<VH> implements MaterialCab.Callback {
+public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, I>
+        extends RecyclerView.Adapter<VH>
+        implements CabCallbacks {
     @Nullable
     private final CabHolder cabHolder;
-    private MaterialCab cab;
+    private AttachedCab cab;
     private final ArrayList<I> checked;
     private int menuRes;
     private final Context context;
 
     private int color;
 
-    public AbsMultiSelectAdapter(Context context, @Nullable CabHolder cabHolder, @MenuRes int menuRes) {
+    protected AbsMultiSelectAdapter(final Context context, @Nullable final CabHolder cabHolder, @MenuRes int menuRes) {
         this.cabHolder = cabHolder;
         checked = new ArrayList<>();
         this.menuRes = menuRes;
@@ -71,13 +76,13 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
 
     private void updateCab() {
         if (cabHolder != null) {
-            if (cab == null || !cab.isActive()) {
+            if (cab == null || !AttachedCabKt.isActive(cab)) {
                 cab = cabHolder.openCab(menuRes, this);
             }
             final int size = checked.size();
-            if (size <= 0) cab.finish();
-            else if (size == 1) cab.setTitle(getName(checked.get(0)));
-            else cab.setTitle(context.getString(R.string.x_selected, size));
+            if (size <= 0) {AttachedCabKt.destroy(cab);}
+            else if (size == 1) {cab.title(CabHolder.UNDEFINED_STRING_RES, getName(checked.get(0)));}
+            else {cab.title(CabHolder.UNDEFINED_STRING_RES, context.getString(R.string.x_selected, size));}
         }
     }
 
@@ -91,7 +96,7 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
     }
 
     protected boolean isInQuickSelectMode() {
-        return cab != null && cab.isActive();
+        return cab != null && AttachedCabKt.isActive(cab);
     }
 
     public void setColor(int color) {
@@ -99,25 +104,24 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
     }
 
     @Override
-    public boolean onCabCreated(MaterialCab materialCab, Menu menu) {
+    public void onCabCreate(final AttachedCab cab, final Menu menu) {
         AbsThemeActivity.static_setStatusbarColor((Activity) context, VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(color));
-        return true;
     }
 
     @Override
-    public boolean onCabItemClicked(MenuItem menuItem) {
+    public boolean onCabSelection(@NonNull final MenuItem menuItem) {
         if (menuItem.getItemId() == R.id.action_multi_select_adapter_check_all) {
             checkAll();
         } else {
             onMultipleItemAction(menuItem, new ArrayList<>(checked));
-            cab.finish();
+            AttachedCabKt.destroy(cab);
             clearChecked();
         }
         return true;
     }
 
     @Override
-    public boolean onCabFinished(MaterialCab materialCab) {
+    public boolean onCabDestroy(final AttachedCab cab) {
         AbsThemeActivity.static_setStatusbarColor((Activity) context, color);
         clearChecked();
         return true;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
@@ -118,10 +118,6 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
         return true;
     }
 
-    protected String getName(@NonNull final I object) {
-        return object.toString();
-    }
-
     @Nullable
     protected abstract I getIdentifier(int position);
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
@@ -2,12 +2,14 @@ package com.poupa.vinylmusicplayer.adapter.base;
 
 import android.app.Activity;
 import android.content.Context;
+import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.afollestad.materialcab.attached.AttachedCab;
@@ -78,8 +80,12 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
             }
             final int size = checked.size();
             if (size <= 0) {AttachedCabKt.destroy(cab);}
-            else if (size == 1) {cab.title(CabHolder.UNDEFINED_STRING_RES, getName(checked.get(0)));}
-            else {cab.title(CabHolder.UNDEFINED_STRING_RES, context.getString(R.string.x_selected, size));}
+            else if (size == 1) {
+                String name = getName(checked.get(0));
+                if (TextUtils.isEmpty(name)) {name = context.getString(R.string.x_selected, 1);}
+                cab.title(ResourcesCompat.ID_NULL, name);
+            }
+            else {cab.title(ResourcesCompat.ID_NULL, context.getString(R.string.x_selected, size));}
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
@@ -42,36 +42,33 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
         this.context = context;
     }
 
-    protected void setMultiSelectMenuRes(@MenuRes int menuRes) {
+    protected void setMultiSelectMenuRes(@MenuRes final int menuRes) {
         this.menuRes = menuRes;
     }
 
     protected boolean toggleChecked(final int position) {
-        if (cabHolder != null) {
-            I identifier = getIdentifier(position);
-            if (identifier == null) return false;
+        final I identifier = getIdentifier(position);
+        if (identifier == null) {return false;}
 
-            if (!checked.remove(identifier)) checked.add(identifier);
+        if (!checked.remove(identifier)) {checked.add(identifier);}
 
-            notifyItemChanged(position);
-            updateCab();
-            return true;
-        }
-        return false;
+        notifyItemChanged(position);
+        updateCab();
+
+        return true;
     }
 
-    protected void checkAll() {
-        if (cabHolder != null) {
-            checked.clear();
-            for (int i = 0; i < getItemCount(); i++) {
-                I identifier = getIdentifier(i);
-                if (identifier != null) {
-                    checked.add(identifier);
-                }
+    private void checkAll() {
+        checked.clear();
+        final int itemCount = getItemCount();
+        for (int i = 0; i < itemCount; i++) {
+            final I identifier = getIdentifier(i);
+            if (identifier != null) {
+                checked.add(identifier);
             }
-            notifyDataSetChanged();
-            updateCab();
         }
+        notifyDataSetChanged();
+        updateCab();
     }
 
     private void updateCab() {
@@ -91,7 +88,7 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
         notifyDataSetChanged();
     }
 
-    protected boolean isChecked(I identifier) {
+    protected boolean isChecked(final I identifier) {
         return checked.contains(identifier);
     }
 
@@ -127,7 +124,7 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
         return true;
     }
 
-    protected String getName(I object) {
+    protected String getName(@NonNull final I object) {
         return object.toString();
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/base/AbsMultiSelectAdapter.java
@@ -37,7 +37,7 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
 
     private int color;
 
-    protected AbsMultiSelectAdapter(final Context context, @Nullable final CabHolder cabHolder, @MenuRes int menuRes) {
+    protected AbsMultiSelectAdapter(final Context context, @NonNull final CabHolder cabHolder, @MenuRes int menuRes) {
         this.cabHolder = cabHolder;
         checked = new ArrayList<>();
         this.menuRes = menuRes;
@@ -74,19 +74,7 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
     }
 
     private void updateCab() {
-        if (cabHolder != null) {
-            if (cab == null || !AttachedCabKt.isActive(cab)) {
-                cab = cabHolder.openCab(menuRes, this);
-            }
-            final int size = checked.size();
-            if (size <= 0) {AttachedCabKt.destroy(cab);}
-            else if (size == 1) {
-                String name = getName(checked.get(0));
-                if (TextUtils.isEmpty(name)) {name = context.getString(R.string.x_selected, 1);}
-                cab.title(ResourcesCompat.ID_NULL, name);
-            }
-            else {cab.title(ResourcesCompat.ID_NULL, context.getString(R.string.x_selected, size));}
-        }
+        cab = CabHolder.updateCab(context, cab, () -> cabHolder.openCab(menuRes, this), checked.size());
     }
 
     private void clearChecked() {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AbsOffsetSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/AbsOffsetSongAdapter.java
@@ -32,7 +32,8 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
     }
 
-    public AbsOffsetSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, boolean usePalette, @Nullable CabHolder cabHolder, boolean showSectionName) {
+    public AbsOffsetSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, boolean usePalette,
+                                @NonNull CabHolder cabHolder, boolean showSectionName) {
         super(activity, dataSet, R.layout.item_list, usePalette, cabHolder, showSectionName);
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
@@ -15,13 +15,15 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.util.Pair;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.glide.GlideApp;
 import com.poupa.vinylmusicplayer.glide.VinylGlideExtension;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongsMenuHelper;
+import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.model.Song;
 import com.poupa.vinylmusicplayer.ui.activities.base.AbsThemeActivity;
@@ -36,10 +38,10 @@ import java.util.ArrayList;
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
-public class ArtistSongAdapter extends ArrayAdapter<Song> implements MaterialCab.Callback {
+public class ArtistSongAdapter extends ArrayAdapter<Song> implements CabCallbacks {
     @Nullable
     private final CabHolder cabHolder;
-    private MaterialCab cab;
+    private AttachedCab cab;
     private ArrayList<Song> dataSet;
     private final ArrayList<Song> checked;
 
@@ -157,15 +159,15 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements MaterialCab
             notifyDataSetChanged();
 
             final int size = checked.size();
-            if (size <= 0) cab.finish();
-            else if (size == 1) cab.setTitle(checked.get(0).title);
-            else cab.setTitle(String.valueOf(size));
+            if (size <= 0) {AttachedCabKt.destroy(cab);}
+            else if (size == 1) cab.title(CabHolder.UNDEFINED_STRING_RES, checked.get(0).title);
+            else cab.title(CabHolder.UNDEFINED_STRING_RES, activity.getString(R.string.x_selected, size));
         }
     }
 
     private void openCabIfNecessary() {
         if (cabHolder != null) {
-            if (cab == null || !cab.isActive()) {
+            if (cab == null || !AttachedCabKt.isActive(cab)) {
                 cab = cabHolder.openCab(R.menu.menu_media_selection, this);
             }
         }
@@ -181,7 +183,7 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements MaterialCab
     }
 
     protected boolean isInQuickSelectMode() {
-        return cab != null && cab.isActive();
+        return cab != null && AttachedCabKt.isActive(cab);
     }
 
     public void setColor(int color) {
@@ -189,21 +191,21 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements MaterialCab
     }
 
     @Override
-    public boolean onCabCreated(MaterialCab materialCab, Menu menu) {
+    public void onCabCreate(AttachedCab materialCab, Menu menu) {
         AbsThemeActivity.static_setStatusbarColor(activity, VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(color));
         return true;
     }
 
     @Override
-    public boolean onCabItemClicked(@NonNull MenuItem menuItem) {
+    public boolean onCabSelection(@NonNull MenuItem menuItem) {
         onMultipleItemAction(menuItem, new ArrayList<>(checked));
-        cab.finish();
+        AttachedCabKt.destroy(cab);
         unCheckAll();
         return true;
     }
 
     @Override
-    public boolean onCabFinished(MaterialCab materialCab) {
+    public boolean onCabDestroy(AttachedCab materialCab) {
         AbsThemeActivity.static_setStatusbarColor(activity, color);
         unCheckAll();
         return true;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
@@ -166,14 +166,6 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements CabCallback
         }
     }
 
-    private void openCabIfNecessary() {
-        if (cabHolder != null) {
-            if (cab == null || !AttachedCabKt.isActive(cab)) {
-                cab = cabHolder.openCab(R.menu.menu_media_selection, this);
-            }
-        }
-    }
-
     private void unCheckAll() {
         checked.clear();
         notifyDataSetChanged();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
@@ -1,6 +1,7 @@
 package com.poupa.vinylmusicplayer.adapter.song;
 
 import android.os.Build;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -13,6 +14,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.core.util.Pair;
 
 import com.afollestad.materialcab.attached.AttachedCab;
@@ -160,8 +162,12 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements CabCallback
 
             final int size = checked.size();
             if (size <= 0) {AttachedCabKt.destroy(cab);}
-            else if (size == 1) cab.title(CabHolder.UNDEFINED_STRING_RES, checked.get(0).title);
-            else cab.title(CabHolder.UNDEFINED_STRING_RES, activity.getString(R.string.x_selected, size));
+            else if (size == 1) {
+                String title = checked.get(0).title;
+                if (TextUtils.isEmpty(title)) {title = activity.getString(R.string.x_selected, 1);}
+                cab.title(ResourcesCompat.ID_NULL, title);
+            }
+            else {cab.title(ResourcesCompat.ID_NULL, activity.getString(R.string.x_selected, size));}
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
@@ -155,19 +155,14 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements CabCallback
 
     protected void toggleChecked(Song song) {
         if (cabHolder != null) {
-            openCabIfNecessary();
-
-            if (!checked.remove(song)) checked.add(song);
+            if (!checked.remove(song)) {checked.add(song);}
             notifyDataSetChanged();
 
-            final int size = checked.size();
-            if (size <= 0) {AttachedCabKt.destroy(cab);}
-            else if (size == 1) {
-                String title = checked.get(0).title;
-                if (TextUtils.isEmpty(title)) {title = activity.getString(R.string.x_selected, 1);}
-                cab.title(ResourcesCompat.ID_NULL, title);
-            }
-            else {cab.title(ResourcesCompat.ID_NULL, activity.getString(R.string.x_selected, size));}
+            cab = CabHolder.updateCab(
+                    activity,
+                    cab,
+                    () -> cabHolder.openCab(R.menu.menu_media_selection, this),
+                    checked.size());
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/ArtistSongAdapter.java
@@ -193,7 +193,6 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements CabCallback
     @Override
     public void onCabCreate(AttachedCab materialCab, Menu menu) {
         AbsThemeActivity.static_setStatusbarColor(activity, VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(color));
-        return true;
     }
 
     @Override

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/OrderablePlaylistSongAdapter.java
@@ -36,7 +36,8 @@ public class OrderablePlaylistSongAdapter
 
     private final OnMoveItemListener onMoveItemListener;
 
-    public OrderablePlaylistSongAdapter(@NonNull AppCompatActivity activity, @NonNull ArrayList<PlaylistSong> dataSet, boolean usePalette, @Nullable CabHolder cabHolder, @Nullable OnMoveItemListener onMoveItemListener) {
+    public OrderablePlaylistSongAdapter(@NonNull AppCompatActivity activity, @NonNull ArrayList<PlaylistSong> dataSet
+            , boolean usePalette, @NonNull CabHolder cabHolder, @Nullable OnMoveItemListener onMoveItemListener) {
         super(activity, (ArrayList<Song>) (List) dataSet, usePalette, cabHolder);
         setMultiSelectMenuRes(R.menu.menu_playlists_songs_selection);
         this.onMoveItemListener = onMoveItemListener;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/PlaylistSongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/PlaylistSongAdapter.java
@@ -24,7 +24,8 @@ import java.util.ArrayList;
  */
 public class PlaylistSongAdapter extends AbsOffsetSongAdapter {
 
-    public PlaylistSongAdapter(AppCompatActivity activity, @NonNull ArrayList<Song> dataSet, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public PlaylistSongAdapter(AppCompatActivity activity, @NonNull ArrayList<Song> dataSet, boolean usePalette,
+                               @NonNull CabHolder cabHolder) {
         super(activity, dataSet, usePalette, cabHolder, false);
         setMultiSelectMenuRes(R.menu.menu_cannot_delete_single_songs_playlist_songs_selection);
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
@@ -188,11 +188,6 @@ public class SongAdapter
     }
 
     @Override
-    protected String getName(Song song) {
-        return song.title;
-    }
-
-    @Override
     protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Song> selection) {
         SongsMenuHelper.handleMenuClick(activity, selection, menuItem.getItemId());
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
@@ -55,11 +55,13 @@ public class SongAdapter
 
     public RecyclerView recyclerView;
 
-    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes,
+                       boolean usePalette, @NonNull CabHolder cabHolder) {
         this(activity, dataSet, itemLayoutRes, usePalette, cabHolder, true);
     }
 
-    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder, boolean showSectionName) {
+    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes,
+                       boolean usePalette, @NonNull CabHolder cabHolder, boolean showSectionName) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
         this.dataSet = dataSet;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/adapter/song/SongAdapter.java
@@ -12,7 +12,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.util.Pair;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialcab.MaterialCab;
 import com.kabouzeid.appthemehelper.util.ColorUtil;
 import com.kabouzeid.appthemehelper.util.MaterialValueHelper;
 import com.poupa.vinylmusicplayer.R;
@@ -40,7 +39,10 @@ import java.util.ArrayList;
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
-public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, Song> implements MaterialCab.Callback, FastScrollRecyclerView.SectionedAdapter {
+public class SongAdapter
+        extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, Song>
+        implements FastScrollRecyclerView.SectionedAdapter
+{
 
     protected final AppCompatActivity activity;
     protected ArrayList<Song> dataSet;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -8,6 +8,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.annotation.ColorInt;
+import androidx.annotation.IdRes;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -47,13 +48,14 @@ public class MenuHelper {
     @NonNull
     public static AttachedCab createAndOpenCab(
             @NonNull final AppCompatActivity context,
+            @IdRes final int cabRes,
             @MenuRes final int menuRes,
             @ColorInt final int backgroundColor,
             @NonNull final CabCallbacks callbacks)
     {
         final AttachedCab attachedCab = MaterialCabKt.createCab(
                 context,
-                R.id.cab_stub,
+                cabRes,
                 cab -> {
                     cab.menu(menuRes);
                     cab.closeDrawable(R.drawable.ic_close_white_24dp);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -1,10 +1,8 @@
 package com.poupa.vinylmusicplayer.helper.menu;
 
-
 import android.content.Context;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
-import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -25,23 +23,26 @@ import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
 import kotlin.Unit;
 
 public class MenuHelper {
-
-    public static void decorateDestructiveItems(Menu menu, Context context) {
-        // All delete element inside of menu should have red text to better differentiate them
+    public static void decorateDestructiveItems(@NonNull final Menu menu, final Context context) {
+        // All delete element inside of menu should have emphasis colored (ie. red) text to better differentiate them
         MenuItem liveItem = menu.findItem(R.id.action_delete_playlist);
-        if (liveItem == null)
+        if (liveItem == null) {
             liveItem = menu.findItem(R.id.action_delete_from_device);
+        }
 
         if (liveItem != null) {
-            SpannableString s = new SpannableString(liveItem.getTitle().toString());
+            final SpannableString span = new SpannableString(liveItem.getTitle().toString());
+
+            // Get the destructive item color as the accent color
+            @ColorInt final int color = ThemeStore.accentColor(context);
 
             // Get delete color from context's theme
             final TypedValue typedColorBackground = new TypedValue();
             context.getTheme().resolveAttribute(R.attr.md_delete, typedColorBackground, true);
             @ColorInt int color = typedColorBackground.data;
 
-            s.setSpan(new ForegroundColorSpan(color), 0, s.length(), 0);
-            liveItem.setTitle(s);
+            span.setSpan(new ForegroundColorSpan(color), 0, span.length(), 0);
+            liveItem.setTitle(span);
         }
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -48,14 +48,13 @@ public class MenuHelper {
     @NonNull
     public static AttachedCab createAndOpenCab(
             @NonNull final AppCompatActivity context,
-            @IdRes final int cabRes,
             @MenuRes final int menuRes,
             @ColorInt final int backgroundColor,
             @NonNull final CabCallbacks callbacks)
     {
         final AttachedCab attachedCab = MaterialCabKt.createCab(
                 context,
-                cabRes,
+                R.id.cab_holder,
                 cab -> {
                     cab.menu(menuRes);
                     cab.closeDrawable(R.drawable.ic_close_white_24dp);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -3,6 +3,7 @@ package com.poupa.vinylmusicplayer.helper.menu;
 import android.content.Context;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
+import android.util.TypedValue;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -32,9 +33,6 @@ public class MenuHelper {
 
         if (liveItem != null) {
             final SpannableString span = new SpannableString(liveItem.getTitle().toString());
-
-            // Get the destructive item color as the accent color
-            @ColorInt final int color = ThemeStore.accentColor(context);
 
             // Get delete color from context's theme
             final TypedValue typedColorBackground = new TypedValue();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -8,21 +8,9 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import androidx.annotation.ColorInt;
-import androidx.annotation.IdRes;
-import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.res.ResourcesCompat;
 
-import com.afollestad.materialcab.MaterialCabKt;
-import com.afollestad.materialcab.attached.AttachedCab;
 import com.poupa.vinylmusicplayer.R;
-import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
-import com.poupa.vinylmusicplayer.interfaces.CabHolder;
-import com.poupa.vinylmusicplayer.util.PreferenceUtil;
-import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
-
-import kotlin.Unit;
 
 public class MenuHelper {
     public static void decorateDestructiveItems(@NonNull final Menu menu, final Context context) {
@@ -43,39 +31,5 @@ public class MenuHelper {
             span.setSpan(new ForegroundColorSpan(color), 0, span.length(), 0);
             liveItem.setTitle(span);
         }
-    }
-
-    @NonNull
-    public static AttachedCab createAndOpenCab(
-            @NonNull final AppCompatActivity context,
-            @MenuRes final int menuRes,
-            @ColorInt final int backgroundColor,
-            @NonNull final CabCallbacks callbacks)
-    {
-        final AttachedCab attachedCab = MaterialCabKt.createCab(
-                context,
-                R.id.cab_holder,
-                cab -> {
-                    cab.menu(menuRes);
-                    cab.closeDrawable(R.drawable.ic_close_white_24dp);
-                    cab.backgroundColor(
-                            ResourcesCompat.ID_NULL,
-                            VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(backgroundColor));
-                    cab.popupTheme(PreferenceUtil.getInstance().getGeneralTheme());
-
-                    cab.onCreate((attachedCab1, menu) -> {
-                        callbacks.onCabCreate(attachedCab1, menu);
-                        return Unit.INSTANCE;
-                    });
-                    cab.onDestroy(callbacks::onCabDestroy);
-                    cab.onSelection(callbacks::onCabSelection);
-                    cab.slideDown(CabHolder.ANIMATION_DELAY_MS);
-
-                    return Unit.INSTANCE;
-                });
-
-        decorateDestructiveItems(attachedCab.getMenu(), context);
-
-        return attachedCab;
     }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/helper/menu/MenuHelper.java
@@ -12,10 +12,10 @@ import androidx.annotation.IdRes;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.res.ResourcesCompat;
 
 import com.afollestad.materialcab.MaterialCabKt;
 import com.afollestad.materialcab.attached.AttachedCab;
-import com.kabouzeid.appthemehelper.ThemeStore;
 import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
@@ -60,7 +60,7 @@ public class MenuHelper {
                     cab.menu(menuRes);
                     cab.closeDrawable(R.drawable.ic_close_white_24dp);
                     cab.backgroundColor(
-                            CabHolder.UNDEFINED_COLOR_RES,
+                            ResourcesCompat.ID_NULL,
                             VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(backgroundColor));
                     cab.popupTheme(PreferenceUtil.getInstance().getGeneralTheme());
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabCallbacks.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabCallbacks.java
@@ -1,0 +1,14 @@
+package com.poupa.vinylmusicplayer.interfaces;
+
+import android.view.Menu;
+import android.view.MenuItem;
+
+import com.afollestad.materialcab.attached.AttachedCab;
+
+public interface CabCallbacks {
+    void onCabCreate(AttachedCab cab, Menu menu);
+
+    boolean onCabDestroy(AttachedCab cab);
+
+    boolean onCabSelection(MenuItem menuItem);
+}

--- a/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabHolder.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabHolder.java
@@ -1,16 +1,12 @@
 package com.poupa.vinylmusicplayer.interfaces;
 
-import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 
 import com.afollestad.materialcab.attached.AttachedCab;
 
 @FunctionalInterface
 public interface CabHolder {
     long ANIMATION_DELAY_MS = 500L;
-    @ColorRes int UNDEFINED_COLOR_RES = 0;
-    @StringRes int UNDEFINED_STRING_RES = 0;
 
     @NonNull
     AttachedCab openCab(final int menuRes, final CabCallbacks callbacks);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabHolder.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabHolder.java
@@ -1,8 +1,24 @@
 package com.poupa.vinylmusicplayer.interfaces;
 
-import androidx.annotation.NonNull;
+import android.content.Context;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.MenuRes;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.res.ResourcesCompat;
+
+import com.afollestad.materialcab.MaterialCabKt;
 import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
+import com.poupa.vinylmusicplayer.R;
+import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
+import com.poupa.vinylmusicplayer.util.PreferenceUtil;
+import com.poupa.vinylmusicplayer.util.VinylMusicPlayerColorUtil;
+
+import java.util.function.Supplier;
+
+import kotlin.Unit;
 
 @FunctionalInterface
 public interface CabHolder {
@@ -10,4 +26,58 @@ public interface CabHolder {
 
     @NonNull
     AttachedCab openCab(final int menuRes, final CabCallbacks callbacks);
+
+    @NonNull
+    static AttachedCab openCabImpl(
+            @NonNull final AppCompatActivity context,
+            @MenuRes final int menuRes,
+            @ColorInt final int backgroundColor,
+            @NonNull final CabCallbacks callbacks)
+    {
+        final AttachedCab attachedCab = MaterialCabKt.createCab(
+                context,
+                R.id.cab_holder,
+                cab -> {
+                    cab.menu(menuRes);
+                    cab.closeDrawable(R.drawable.ic_close_white_24dp);
+                    cab.backgroundColor(
+                            ResourcesCompat.ID_NULL,
+                            VinylMusicPlayerColorUtil.shiftBackgroundColorForLightText(backgroundColor));
+                    cab.popupTheme(PreferenceUtil.getInstance().getGeneralTheme());
+
+                    cab.onCreate((attachedCab1, menu) -> {
+                        callbacks.onCabCreate(attachedCab1, menu);
+                        return Unit.INSTANCE;
+                    });
+                    cab.onDestroy(callbacks::onCabDestroy);
+                    cab.onSelection(callbacks::onCabSelection);
+                    cab.slideDown(ANIMATION_DELAY_MS);
+
+                    return Unit.INSTANCE;
+                });
+
+        MenuHelper.decorateDestructiveItems(attachedCab.getMenu(), context);
+
+        return attachedCab;
+    }
+
+    @NonNull
+    static AttachedCab updateCab(@NonNull Context context, @NonNull AttachedCab cab,
+                                 @NonNull final Supplier<AttachedCab> openCabFunction,
+                                 int checkedCount) {
+        if (checkedCount <= 0) {
+            AttachedCabKt.destroy(cab);
+        }
+        else {
+            if (!AttachedCabKt.isActive(cab)) {
+                cab = openCabFunction.get();
+            }
+            cab.title(ResourcesCompat.ID_NULL,
+                    (checkedCount == 1)
+                            ? context.getString(R.string.x_selected, 1)
+                            : context.getString(R.string.x_selected, checkedCount)
+            );
+        }
+        return cab;
+    }
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabHolder.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/interfaces/CabHolder.java
@@ -1,14 +1,17 @@
 package com.poupa.vinylmusicplayer.interfaces;
 
+import androidx.annotation.ColorRes;
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
 
-/**
- * @author Karim Abou Zeid (kabouzeid)
- */
+@FunctionalInterface
 public interface CabHolder {
+    long ANIMATION_DELAY_MS = 500L;
+    @ColorRes int UNDEFINED_COLOR_RES = 0;
+    @StringRes int UNDEFINED_STRING_RES = 0;
 
     @NonNull
-    MaterialCab openCab(final int menuRes, final MaterialCab.Callback callback);
+    AttachedCab openCab(final int menuRes, final CabCallbacks callbacks);
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/misc/SimpleObservableScrollViewCallbacks.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/misc/SimpleObservableScrollViewCallbacks.java
@@ -8,17 +8,11 @@ import com.github.ksoichiro.android.observablescrollview.ScrollState;
  */
 public abstract class SimpleObservableScrollViewCallbacks implements ObservableScrollViewCallbacks {
     @Override
-    public void onScrollChanged(int i, boolean b, boolean b2) {
-
-    }
+    public void onScrollChanged(int scrollY, boolean firstScroll, boolean dragging) {}
 
     @Override
-    public void onDownMotionEvent() {
-
-    }
+    public void onDownMotionEvent() {}
 
     @Override
-    public void onUpOrCancelMotionEvent(ScrollState scrollState) {
-
-    }
+    public void onUpOrCancelMotionEvent(ScrollState scrollState) {}
 }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/Playlist.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/Playlist.java
@@ -9,6 +9,8 @@ import androidx.annotation.NonNull;
 import com.poupa.vinylmusicplayer.loader.PlaylistSongLoader;
 import com.poupa.vinylmusicplayer.util.MusicUtil;
 
+import org.jetbrains.annotations.NonNls;
+
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -17,6 +19,7 @@ import java.util.Objects;
  */
 public class Playlist implements Parcelable {
     public final long id;
+    @NonNls
     public final String name;
 
     public Playlist(final long id, final String name) {

--- a/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/model/Song.java
@@ -8,6 +8,8 @@ import androidx.annotation.NonNull;
 
 import com.poupa.vinylmusicplayer.discog.tagging.MultiValuesTagUtil;
 
+import org.jetbrains.annotations.NonNls;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +28,7 @@ public class Song implements Parcelable {
     public long albumId;
     public List<String> artistNames = new ArrayList<>(Arrays.asList(""));
     public long artistId; // TODO This field is ambiguous - song's first artist or album first artist?
+    @NonNls
     public final String data;
     public final long dateAdded;
     public final long dateModified;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -116,7 +116,7 @@ public class AlbumDetailActivity
     private final SimpleObservableScrollViewCallbacks observableScrollViewCallbacks = new SimpleObservableScrollViewCallbacks() {
         @Override
         public void onScrollChanged(int scrollY, boolean firstScroll, boolean dragging) {
-            int y = scrollY|+ headerViewHeight;
+            int y = scrollY + headerViewHeight;
 
             // Change alpha of overlay
             final float headerAlpha = Math.max(0, Math.min(1, (float) 2 * y / headerViewHeight));

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -347,11 +347,11 @@ public class AlbumDetailActivity
     @NonNull
     @Override
     public AttachedCab openCab(int menuRes, @NonNull final CabCallbacks callbacks) {
-        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
+        AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = getPaletteColor();
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubAlbum.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -13,6 +13,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
@@ -21,7 +22,8 @@ import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.util.DialogUtils;
 import com.github.ksoichiro.android.observablescrollview.ObservableRecyclerView;
@@ -39,6 +41,7 @@ import com.poupa.vinylmusicplayer.glide.VinylColoredTarget;
 import com.poupa.vinylmusicplayer.glide.VinylGlideExtension;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
+import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.interfaces.PaletteColorHolder;
@@ -67,7 +70,9 @@ import retrofit2.Response;
 /**
  * Be careful when changing things in this Activity!
  */
-public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements PaletteColorHolder, CabHolder, LoaderManager.LoaderCallbacks<Album> {
+public class AlbumDetailActivity
+        extends AbsSlidingMusicPanelActivity
+        implements PaletteColorHolder, CabHolder, LoaderManager.LoaderCallbacks<Album> {
 
     private static final int TAG_EDITOR_REQUEST = 2001;
     private static final int LOADER_ID = LoaderIds.ALBUM_DETAIL_ACTIVITY;
@@ -95,7 +100,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
 
     private AlbumSongAdapter adapter;
 
-    private MaterialCab cab;
+    private AttachedCab cab;
     private int headerViewHeight;
     private int toolbarColor;
 
@@ -381,35 +386,18 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
 
     @NonNull
     @Override
-    public MaterialCab openCab(int menuRes, @NonNull final MaterialCab.Callback callback) {
-        if (cab != null && cab.isActive()) cab.finish();
-        adapter.setColor(getPaletteColor());
-        cab = MenuHelper.setOverflowMenu(this, menuRes, getPaletteColor())
-                .start(new MaterialCab.Callback() {
-                    @Override
-                    public boolean onCabCreated(MaterialCab materialCab, Menu menu) {
-                        return callback.onCabCreated(materialCab, menu);
-                    }
+    public AttachedCab openCab(int menuRes, @NonNull final CabCallbacks callbacks) {
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
 
-                    @Override
-                    public boolean onCabItemClicked(MenuItem menuItem) {
-                        return callback.onCabItemClicked(menuItem);
-                    }
-
-                    @Override
-                    public boolean onCabFinished(MaterialCab materialCab) {
-                        return callback.onCabFinished(materialCab);
-                    }
-                });
-
-        MenuHelper.decorateDestructiveItems(cab.getMenu(), this);
-
+        @ColorInt final int color = getPaletteColor();
+        adapter.setColor(color);
+        cab = MenuHelper.createAndOpenCab(this, menuRes, color, callbacks);
         return cab;
     }
 
     @Override
     public void onBackPressed() {
-        if (cab != null && cab.isActive()) cab.finish();
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
         else {
             recyclerView.stopScroll();
             super.onBackPressed();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -351,7 +351,7 @@ public class AlbumDetailActivity
 
         @ColorInt final int color = getPaletteColor();
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -81,22 +81,22 @@ public class AlbumDetailActivity
 
     private Album album;
 
-    ObservableRecyclerView recyclerView;
-    com.google.android.material.card.MaterialCardView albumBorderTheme;
-    ImageView albumArtImageView;
-    Toolbar toolbar;
-    View headerView;
-    View headerOverlay;
+    private ObservableRecyclerView recyclerView;
+    private com.google.android.material.card.MaterialCardView albumBorderTheme;
+    private ImageView albumArtImageView;
+    private Toolbar toolbar;
+    private View headerView;
+    private View headerOverlay;
 
-    ImageView artistIconImageView;
-    ImageView durationIconImageView;
-    ImageView songCountIconImageView;
-    ImageView albumYearIconImageView;
-    TextView artistTextView;
-    TextView durationTextView;
-    TextView songCountTextView;
-    TextView albumYearTextView;
-    TextView titleTextView;
+    private ImageView artistIconImageView;
+    private ImageView durationIconImageView;
+    private ImageView songCountIconImageView;
+    private ImageView albumYearIconImageView;
+    private TextView artistTextView;
+    private TextView durationTextView;
+    private TextView songCountTextView;
+    private TextView albumYearTextView;
+    private TextView titleTextView;
 
     private AlbumSongAdapter adapter;
 
@@ -110,7 +110,7 @@ public class AlbumDetailActivity
     private LastFMRestClient lastFMRestClient;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setDrawUnderStatusbar();
 
@@ -125,8 +125,8 @@ public class AlbumDetailActivity
 
     @Override
     protected View createContentView() {
-        SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
-        ActivityAlbumDetailBinding binding = ActivityAlbumDetailBinding.inflate(
+        final SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
+        final ActivityAlbumDetailBinding binding = ActivityAlbumDetailBinding.inflate(
                 getLayoutInflater(),
                 slidingPanelBinding.contentContainer,
                 true);
@@ -153,17 +153,17 @@ public class AlbumDetailActivity
 
     private final SimpleObservableScrollViewCallbacks observableScrollViewCallbacks = new SimpleObservableScrollViewCallbacks() {
         @Override
-        public void onScrollChanged(int scrollY, boolean b, boolean b2) {
-            scrollY += headerViewHeight;
+        public void onScrollChanged(int scrollY, boolean firstScroll, boolean dragging) {
+            int y = scrollY|+ headerViewHeight;
 
             // Change alpha of overlay
-            float headerAlpha = Math.max(0, Math.min(1, (float) 2 * scrollY / headerViewHeight));
+            final float headerAlpha = Math.max(0, Math.min(1, (float) 2 * y / headerViewHeight));
             headerOverlay.setBackgroundColor(ColorUtil.withAlpha(toolbarColor, headerAlpha));
 
             // Translate name text
-            headerView.setTranslationY(Math.max(-scrollY, -headerViewHeight));
-            headerOverlay.setTranslationY(Math.max(-scrollY, -headerViewHeight));
-            albumBorderTheme.setTranslationY(Math.max(-scrollY, -headerViewHeight));
+            headerView.setTranslationY(Math.max(-y, -headerViewHeight));
+            headerOverlay.setTranslationY(Math.max(-y, -headerViewHeight));
+            albumBorderTheme.setTranslationY(Math.max(-y, -headerViewHeight));
         }
     };
 
@@ -210,7 +210,7 @@ public class AlbumDetailActivity
         setSupportActionBar(toolbar); // needed to auto readjust the toolbar content color
         setStatusbarColor(color);
 
-        int secondaryTextColor = MaterialValueHelper.getSecondaryTextColor(this, ColorUtil.isColorLight(color));
+        final int secondaryTextColor = MaterialValueHelper.getSecondaryTextColor(this, ColorUtil.isColorLight(color));
         artistIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
         durationIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
         songCountIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
@@ -254,7 +254,7 @@ public class AlbumDetailActivity
             @Override
             public void onChanged() {
                 super.onChanged();
-                if (adapter.getItemCount() == 0) finish();
+                if (adapter.getItemCount() == 0) {finish();}
             }
         });
     }
@@ -265,7 +265,7 @@ public class AlbumDetailActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(final Menu menu) {
         getMenuInflater().inflate(R.menu.menu_album_detail, menu);
 
         MenuHelper.decorateDestructiveItems(menu, this);
@@ -317,8 +317,8 @@ public class AlbumDetailActivity
     }
 
     @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        int id = item.getItemId();
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        final int id = item.getItemId();
         final ArrayList<Song> songs = adapter.getDataSet();
         if (id == R.id.action_sleep_timer) {
             new SleepTimerDialog().show(getSupportFragmentManager(), "SET_SLEEP_TIMER");
@@ -345,7 +345,7 @@ public class AlbumDetailActivity
             super.onBackPressed();
             return true;
         } else if (id == R.id.action_tag_editor) {
-            Intent intent = new Intent(this, AlbumTagEditorActivity.class);
+            final Intent intent = new Intent(this, AlbumTagEditorActivity.class);
             intent.putExtra(AbsTagEditorActivity.EXTRA_ID, getAlbum().getId());
             startActivityForResult(intent, TAG_EDITOR_REQUEST);
             return true;
@@ -376,7 +376,7 @@ public class AlbumDetailActivity
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    protected void onActivityResult(int requestCode, int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == TAG_EDITOR_REQUEST) {
             reload();
@@ -426,7 +426,7 @@ public class AlbumDetailActivity
         setLightStatusbar(false);
     }
 
-    private void setAlbum(Album album) {
+    private void setAlbum(final Album album) {
         this.album = album;
         loadAlbumCover();
 
@@ -444,23 +444,23 @@ public class AlbumDetailActivity
     }
 
     private Album getAlbum() {
-        if (album == null) album = new Album();
+        if (album == null) {album = new Album();}
         return album;
     }
 
     @Override
     @NonNull
-    public Loader<Album> onCreateLoader(int id, Bundle args) {
+    public Loader<Album> onCreateLoader(int id, @NonNull final Bundle args) {
         return new AsyncAlbumLoader(this, args.getLong(EXTRA_ALBUM_ID));
     }
 
     @Override
-    public void onLoadFinished(@NonNull Loader<Album> loader, Album data) {
+    public void onLoadFinished(@NonNull final Loader<Album> loader, final Album data) {
         setAlbum(data);
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader<Album> loader) {
+    public void onLoaderReset(@NonNull final Loader<Album> loader) {
         this.album = new Album();
         adapter.swapDataSet(album.songs);
     }
@@ -468,11 +468,12 @@ public class AlbumDetailActivity
     private static class AsyncAlbumLoader extends WrappedAsyncTaskLoader<Album> {
         private final long albumId;
 
-        public AsyncAlbumLoader(Context context, long albumId) {
+        AsyncAlbumLoader(final Context context, long albumId) {
             super(context);
             this.albumId = albumId;
         }
 
+        @NonNull
         @Override
         public Album loadInBackground() {
             return AlbumLoader.getAlbum(albumId);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -9,14 +9,11 @@ import android.text.Spanned;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.ImageView;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.GridLayoutManager;
@@ -26,7 +23,6 @@ import com.afollestad.materialcab.attached.AttachedCab;
 import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.util.DialogUtils;
-import com.github.ksoichiro.android.observablescrollview.ObservableRecyclerView;
 import com.kabouzeid.appthemehelper.util.ColorUtil;
 import com.kabouzeid.appthemehelper.util.MaterialValueHelper;
 import com.poupa.vinylmusicplayer.R;
@@ -81,25 +77,8 @@ public class AlbumDetailActivity
 
     private Album album;
 
-    private ObservableRecyclerView recyclerView;
-    private com.google.android.material.card.MaterialCardView albumBorderTheme;
-    private ImageView albumArtImageView;
-    private Toolbar toolbar;
-    private View headerView;
-    private View headerOverlay;
-
-    private ImageView artistIconImageView;
-    private ImageView durationIconImageView;
-    private ImageView songCountIconImageView;
-    private ImageView albumYearIconImageView;
-    private TextView artistTextView;
-    private TextView durationTextView;
-    private TextView songCountTextView;
-    private TextView albumYearTextView;
-    private TextView titleTextView;
-
+    private ActivityAlbumDetailBinding layoutBinding;
     private AlbumSongAdapter adapter;
-
     private AttachedCab cab;
     private int headerViewHeight;
     private int toolbarColor;
@@ -126,27 +105,10 @@ public class AlbumDetailActivity
     @Override
     protected View createContentView() {
         final SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
-        final ActivityAlbumDetailBinding binding = ActivityAlbumDetailBinding.inflate(
+        layoutBinding = ActivityAlbumDetailBinding.inflate(
                 getLayoutInflater(),
                 slidingPanelBinding.contentContainer,
                 true);
-
-        recyclerView = binding.list;
-        albumBorderTheme = binding.imageBorderTheme;
-        albumArtImageView = binding.image;
-        toolbar = binding.toolbar;
-        headerView = binding.header;
-        headerOverlay = binding.headerOverlay;
-
-        artistIconImageView = binding.artistIcon;
-        durationIconImageView = binding.durationIcon;
-        songCountIconImageView = binding.songCountIcon;
-        albumYearIconImageView = binding.albumYearIcon;
-        artistTextView = binding.artistText;
-        durationTextView = binding.durationText;
-        songCountTextView = binding.songCountText;
-        albumYearTextView = binding.albumYearText;
-        titleTextView = binding.title;
 
         return slidingPanelBinding.getRoot();
     }
@@ -158,12 +120,12 @@ public class AlbumDetailActivity
 
             // Change alpha of overlay
             final float headerAlpha = Math.max(0, Math.min(1, (float) 2 * y / headerViewHeight));
-            headerOverlay.setBackgroundColor(ColorUtil.withAlpha(toolbarColor, headerAlpha));
+            layoutBinding.headerOverlay.setBackgroundColor(ColorUtil.withAlpha(toolbarColor, headerAlpha));
 
             // Translate name text
-            headerView.setTranslationY(Math.max(-y, -headerViewHeight));
-            headerOverlay.setTranslationY(Math.max(-y, -headerViewHeight));
-            albumBorderTheme.setTranslationY(Math.max(-y, -headerViewHeight));
+            layoutBinding.header.setTranslationY(Math.max(-y, -headerViewHeight));
+            layoutBinding.headerOverlay.setTranslationY(Math.max(-y, -headerViewHeight));
+            layoutBinding.imageBorderTheme.setTranslationY(Math.max(-y, -headerViewHeight));
         }
     };
 
@@ -174,7 +136,7 @@ public class AlbumDetailActivity
     private void setUpViews() {
         setUpRecyclerView();
         setUpSongsAdapter();
-        artistTextView.setOnClickListener(v -> {
+        layoutBinding.artistText.setOnClickListener(v -> {
             if (album != null) {
                 NavigationUtil.goToArtist(AlbumDetailActivity.this, album.getArtistId());
             }
@@ -189,38 +151,37 @@ public class AlbumDetailActivity
                 .transition(VinylGlideExtension.getDefaultTransition())
                 .songOptions(getAlbum().safeGetFirstSong())
                 .dontAnimate()
-                .into(new VinylColoredTarget(albumArtImageView) {
+                .into(new VinylColoredTarget(layoutBinding.image) {
                     @Override
                     public void onColorReady(int color) {
                         setColors(color);
                     }
                 });
 
-        albumBorderTheme.setRadius(ThemeStyleUtil.getInstance().getAlbumRadiusImage(AlbumDetailActivity.this));
+        layoutBinding.imageBorderTheme.setRadius(ThemeStyleUtil.getInstance().getAlbumRadiusImage(AlbumDetailActivity.this));
     }
 
     private void setColors(int color) {
         toolbarColor = color;
-        headerView.setBackgroundColor(color);
+        layoutBinding.header.setBackgroundColor(color);
 
         setNavigationbarColor(color);
         setTaskDescriptionColor(color);
 
-        toolbar.setBackgroundColor(color);
-        setSupportActionBar(toolbar); // needed to auto readjust the toolbar content color
+        layoutBinding.toolbar.setBackgroundColor(color);
+        setSupportActionBar(layoutBinding.toolbar); // needed to auto readjust the toolbar content color
         setStatusbarColor(color);
 
         final int secondaryTextColor = MaterialValueHelper.getSecondaryTextColor(this, ColorUtil.isColorLight(color));
-        artistIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
-        durationIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
-        songCountIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
-        albumYearIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
-        artistTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
-        durationTextView.setTextColor(secondaryTextColor);
-        songCountTextView.setTextColor(secondaryTextColor);
-        albumYearTextView.setTextColor(secondaryTextColor);
-
-        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
+        layoutBinding.artistIcon.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
+        layoutBinding.durationIcon.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
+        layoutBinding.songCountIcon.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
+        layoutBinding.albumYearIcon.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
+        layoutBinding.artistText.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
+        layoutBinding.durationText.setTextColor(secondaryTextColor);
+        layoutBinding.songCountText.setTextColor(secondaryTextColor);
+        layoutBinding.albumYearText.setTextColor(secondaryTextColor);
+        layoutBinding.title.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
     }
 
     @Override
@@ -230,26 +191,25 @@ public class AlbumDetailActivity
 
     private void setUpRecyclerView() {
         setUpRecyclerViewPadding();
-        recyclerView.setScrollViewCallbacks(observableScrollViewCallbacks);
+        layoutBinding.list.setScrollViewCallbacks(observableScrollViewCallbacks);
         final View contentView = getWindow().getDecorView().findViewById(android.R.id.content);
         contentView.post(() -> observableScrollViewCallbacks.onScrollChanged(-headerViewHeight, false, false));
     }
 
     private void setUpRecyclerViewPadding() {
-        recyclerView.setPadding(0, headerViewHeight, 0, 0);
+        layoutBinding.list.setPadding(0, headerViewHeight, 0, 0);
     }
 
     private void setUpToolBar() {
-        setSupportActionBar(toolbar);
-        //noinspection ConstantConditions
+        setSupportActionBar(layoutBinding.toolbar);
         getSupportActionBar().setTitle(null);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 
     private void setUpSongsAdapter() {
         adapter = new AlbumSongAdapter(this, getAlbum().songs, false, this);
-        recyclerView.setLayoutManager(new GridLayoutManager(this, 1));
-        recyclerView.setAdapter(adapter);
+        layoutBinding.list.setLayoutManager(new GridLayoutManager(this, 1));
+        layoutBinding.list.setAdapter(adapter);
         adapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
             @Override
             public void onChanged() {
@@ -391,7 +351,7 @@ public class AlbumDetailActivity
 
         @ColorInt final int color = getPaletteColor();
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubAlbum.getId(), menuRes, color, callbacks);
         return cab;
     }
 
@@ -399,7 +359,7 @@ public class AlbumDetailActivity
     public void onBackPressed() {
         if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
         else {
-            recyclerView.stopScroll();
+            layoutBinding.list.stopScroll();
             super.onBackPressed();
         }
     }
@@ -434,11 +394,11 @@ public class AlbumDetailActivity
             loadWiki();
         }
 
-        titleTextView.setText(album.getTitle());
-        artistTextView.setText(album.getArtistName());
-        songCountTextView.setText(MusicUtil.getSongCountString(this, album.getSongCount()));
-        durationTextView.setText(MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(album.songs)));
-        albumYearTextView.setText(MusicUtil.getYearString(album.getYear()));
+        layoutBinding.title.setText(album.getTitle());
+        layoutBinding.artistText.setText(album.getArtistName());
+        layoutBinding.songCountText.setText(MusicUtil.getSongCountString(this, album.getSongCount()));
+        layoutBinding.durationText.setText(MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(album.songs)));
+        layoutBinding.albumYearText.setText(MusicUtil.getYearString(album.getYear()));
 
         adapter.swapDataSet(album.songs);
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/AlbumDetailActivity.java
@@ -351,7 +351,7 @@ public class AlbumDetailActivity
 
         @ColorInt final int color = getPaletteColor();
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, menuRes, color, callbacks);
+        cab = CabHolder.openCabImpl(this, menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -79,23 +79,23 @@ public class ArtistDetailActivity
 
     public static final String EXTRA_ARTIST_ID = "extra_artist_id";
 
-    ObservableListView songListView;
-    com.google.android.material.card.MaterialCardView artistBorderTheme;
-    ImageView artistImage;
-    Toolbar toolbar;
-    View headerView;
-    View headerOverlay;
+    private ObservableListView songListView;
+    private com.google.android.material.card.MaterialCardView artistBorderTheme;
+    private ImageView artistImage;
+    private Toolbar toolbar;
+    private View headerView;
+    private View headerOverlay;
 
-    ImageView durationIconImageView;
-    ImageView songCountIconImageView;
-    ImageView albumCountIconImageView;
-    TextView durationTextView;
-    TextView songCountTextView;
-    TextView albumCountTextView;
-    TextView titleTextView;
+    private ImageView durationIconImageView;
+    private ImageView songCountIconImageView;
+    private ImageView albumCountIconImageView;
+    private TextView durationTextView;
+    private TextView songCountTextView;
+    private TextView albumCountTextView;
+    private TextView titleTextView;
 
-    View songListHeader;
-    RecyclerView albumRecyclerView;
+    private View songListHeader;
+    private RecyclerView albumRecyclerView;
 
     private AttachedCab cab;
     private int headerViewHeight;
@@ -113,22 +113,22 @@ public class ArtistDetailActivity
     private boolean forceDownload;
     private final SimpleObservableScrollViewCallbacks observableScrollViewCallbacks = new SimpleObservableScrollViewCallbacks() {
         @Override
-        public void onScrollChanged(int scrollY, boolean b, boolean b2) {
-            scrollY += headerViewHeight;
+        public void onScrollChanged(int scrollY, boolean firstScroll, boolean dragging) {
+            final int y = scrollY + headerViewHeight;
 
             // Change alpha of overlay
-            float headerAlpha = Math.max(0, Math.min(1, (float) 2 * scrollY / headerViewHeight));
+            final float headerAlpha = Math.max(0, Math.min(1, (float) 2 * y / headerViewHeight));
             headerOverlay.setBackgroundColor(ColorUtil.withAlpha(toolbarColor, headerAlpha));
 
             // Translate name text
-            headerView.setTranslationY(Math.max(-scrollY, -headerViewHeight));
-            headerOverlay.setTranslationY(Math.max(-scrollY, -headerViewHeight));
-            artistBorderTheme.setTranslationY(Math.max(-scrollY, -headerViewHeight));
+            headerView.setTranslationY(Math.max(-y, -headerViewHeight));
+            headerOverlay.setTranslationY(Math.max(-y, -headerViewHeight));
+            artistBorderTheme.setTranslationY(Math.max(-y, -headerViewHeight));
         }
     };
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setDrawUnderStatusbar();
 
@@ -145,8 +145,8 @@ public class ArtistDetailActivity
 
     @Override
     protected View createContentView() {
-        SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
-        ActivityArtistDetailBinding binding = ActivityArtistDetailBinding.inflate(
+        final SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
+        final ActivityArtistDetailBinding binding = ActivityArtistDetailBinding.inflate(
                 getLayoutInflater(),
                 slidingPanelBinding.contentContainer,
                 true);
@@ -210,12 +210,12 @@ public class ArtistDetailActivity
             @Override
             public void onChanged() {
                 super.onChanged();
-                if (albumAdapter.getItemCount() == 0) finish();
+                if (albumAdapter.getItemCount() == 0) {finish();}
             }
         });
     }
 
-    protected void setUsePalette(boolean usePalette) {
+    private void setUsePalette(boolean usePalette) {
         albumAdapter.usePalette(usePalette);
         PreferenceUtil.getInstance().setAlbumArtistColoredFooters(usePalette);
         this.usePalette = usePalette;
@@ -235,9 +235,9 @@ public class ArtistDetailActivity
 
         lastFMRestClient.getApiService()
                 .getArtistInfo(getArtist().getName(), lang, null)
-                .enqueue(new Callback<LastFmArtist>() {
+                .enqueue(new Callback<>() {
                     @Override
-                    public void onResponse(@NonNull Call<LastFmArtist> call, @NonNull Response<LastFmArtist> response) {
+                    public void onResponse(@NonNull final Call<LastFmArtist> call, @NonNull final Response<LastFmArtist> response) {
                         final LastFmArtist lastFmArtist = response.body();
                         if (lastFmArtist != null && lastFmArtist.getArtist() != null && lastFmArtist.getArtist().getBio() != null) {
                             final String bioContent = lastFmArtist.getArtist().getBio().getContent();
@@ -263,7 +263,7 @@ public class ArtistDetailActivity
                     }
 
                     @Override
-                    public void onFailure(@NonNull Call<LastFmArtist> call, @NonNull Throwable t) {
+                    public void onFailure(@NonNull final Call<LastFmArtist> call, @NonNull final Throwable t) {
                         t.printStackTrace();
                         biography = null;
                     }
@@ -288,7 +288,7 @@ public class ArtistDetailActivity
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    protected void onActivityResult(int requestCode, int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_CODE_SELECT_IMAGE) {
             if (resultCode == RESULT_OK) {
@@ -317,7 +317,7 @@ public class ArtistDetailActivity
         setSupportActionBar(toolbar); // needed to auto readjust the toolbar content color
         setStatusbarColor(color);
 
-        int secondaryTextColor = MaterialValueHelper.getSecondaryTextColor(this, ColorUtil.isColorLight(color));
+        final int secondaryTextColor = MaterialValueHelper.getSecondaryTextColor(this, ColorUtil.isColorLight(color));
         durationIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
         songCountIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
         albumCountIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
@@ -336,15 +336,15 @@ public class ArtistDetailActivity
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(final Menu menu) {
         getMenuInflater().inflate(R.menu.menu_artist_detail, menu);
         menu.findItem(R.id.action_colored_footers).setChecked(usePalette);
         return super.onCreateOptionsMenu(menu);
     }
 
     @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        int id = item.getItemId();
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        final int id = item.getItemId();
         final ArrayList<Song> songs = songAdapter.getDataSet();
         if (id == R.id.action_sleep_timer) {
             new SleepTimerDialog().show(getSupportFragmentManager(), "SET_SLEEP_TIMER");
@@ -374,12 +374,12 @@ public class ArtistDetailActivity
                         .positiveText(android.R.string.ok)
                         .build();
             }
-            if (PreferenceUtil.isAllowedToDownloadMetadata(ArtistDetailActivity.this)) { // wiki should've been already downloaded
+            if (PreferenceUtil.isAllowedToDownloadMetadata(this)) { // wiki should've been already downloaded
                 if (biography != null) {
                     biographyDialog.setContent(biography);
                     biographyDialog.show();
                 } else {
-                    Toast.makeText(ArtistDetailActivity.this, getResources().getString(R.string.biography_unavailable), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, getResources().getString(R.string.biography_unavailable), Toast.LENGTH_SHORT).show();
                 }
             } else { // force download
                 biographyDialog.show();
@@ -387,7 +387,7 @@ public class ArtistDetailActivity
             }
             return true;
         } else if (id == R.id.action_set_artist_image) {
-            Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+            final Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
             intent.setType("image/*");
             startActivityForResult(Intent.createChooser(intent, getString(R.string.pick_from_local_storage)), REQUEST_CODE_SELECT_IMAGE);
             return true;
@@ -430,7 +430,7 @@ public class ArtistDetailActivity
         setLightStatusbar(false);
     }
 
-    private void setArtist(Artist artist) {
+    private void setArtist(final Artist artist) {
         this.artist = artist;
         loadArtistImage();
 
@@ -448,13 +448,13 @@ public class ArtistDetailActivity
     }
 
     private Artist getArtist() {
-        if (artist == null) artist = Artist.EMPTY;
+        if (artist == null) {artist = Artist.EMPTY;}
         return artist;
     }
 
     @Override
     @NonNull
-    public Loader<Artist> onCreateLoader(int id, Bundle args) {
+    public Loader<Artist> onCreateLoader(int id, @NonNull final Bundle args) {
         return new AsyncArtistDataLoader(this, args.getLong(EXTRA_ARTIST_ID));
     }
 
@@ -475,12 +475,12 @@ public class ArtistDetailActivity
     }
 
     @Override
-    public void onLoadFinished(@NonNull Loader<Artist> loader, Artist data) {
+    public void onLoadFinished(@NonNull final Loader<Artist> loader, final Artist data) {
         setArtist(data);
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader<Artist> loader) {
+    public void onLoaderReset(@NonNull final Loader<Artist> loader) {
         this.artist = Artist.EMPTY;
         songAdapter.swapDataSet(artist.getSongs());
         albumAdapter.swapDataSet(artist.albums);
@@ -489,7 +489,7 @@ public class ArtistDetailActivity
     private static class AsyncArtistDataLoader extends WrappedAsyncTaskLoader<Artist> {
         private final long artistId;
 
-        public AsyncArtistDataLoader(Context context, long artistId) {
+        AsyncArtistDataLoader(final Context context, long artistId) {
             super(context);
             this.artistId = artistId;
         }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -37,7 +37,6 @@ import com.poupa.vinylmusicplayer.glide.GlideApp;
 import com.poupa.vinylmusicplayer.glide.VinylColoredTarget;
 import com.poupa.vinylmusicplayer.glide.VinylGlideExtension;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
-import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
@@ -377,7 +376,7 @@ public class ArtistDetailActivity
 
         @ColorInt final int color = getPaletteColor();
         songAdapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, menuRes, color, callbacks);
+        cab = CabHolder.openCabImpl(this, menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -373,11 +373,11 @@ public class ArtistDetailActivity
     @NonNull
     @Override
     public AttachedCab openCab(int menuRes, @NonNull final CabCallbacks callbacks) {
-        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
+        AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = getPaletteColor();
         songAdapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubArtist.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -10,14 +10,11 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.ImageView;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -27,7 +24,6 @@ import com.afollestad.materialcab.attached.AttachedCab;
 import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.util.DialogUtils;
-import com.github.ksoichiro.android.observablescrollview.ObservableListView;
 import com.kabouzeid.appthemehelper.util.ColorUtil;
 import com.kabouzeid.appthemehelper.util.MaterialValueHelper;
 import com.poupa.vinylmusicplayer.R;
@@ -79,20 +75,7 @@ public class ArtistDetailActivity
 
     public static final String EXTRA_ARTIST_ID = "extra_artist_id";
 
-    private ObservableListView songListView;
-    private com.google.android.material.card.MaterialCardView artistBorderTheme;
-    private ImageView artistImage;
-    private Toolbar toolbar;
-    private View headerView;
-    private View headerOverlay;
-
-    private ImageView durationIconImageView;
-    private ImageView songCountIconImageView;
-    private ImageView albumCountIconImageView;
-    private TextView durationTextView;
-    private TextView songCountTextView;
-    private TextView albumCountTextView;
-    private TextView titleTextView;
+    private ActivityArtistDetailBinding layoutBinding;
 
     private View songListHeader;
     private RecyclerView albumRecyclerView;
@@ -118,12 +101,12 @@ public class ArtistDetailActivity
 
             // Change alpha of overlay
             final float headerAlpha = Math.max(0, Math.min(1, (float) 2 * y / headerViewHeight));
-            headerOverlay.setBackgroundColor(ColorUtil.withAlpha(toolbarColor, headerAlpha));
+            layoutBinding.headerOverlay.setBackgroundColor(ColorUtil.withAlpha(toolbarColor, headerAlpha));
 
             // Translate name text
-            headerView.setTranslationY(Math.max(-y, -headerViewHeight));
-            headerOverlay.setTranslationY(Math.max(-y, -headerViewHeight));
-            artistBorderTheme.setTranslationY(Math.max(-y, -headerViewHeight));
+            layoutBinding.header.setTranslationY(Math.max(-y, -headerViewHeight));
+            layoutBinding.headerOverlay.setTranslationY(Math.max(-y, -headerViewHeight));
+            layoutBinding.imageBorderTheme.setTranslationY(Math.max(-y, -headerViewHeight));
         }
     };
 
@@ -146,25 +129,10 @@ public class ArtistDetailActivity
     @Override
     protected View createContentView() {
         final SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
-        final ActivityArtistDetailBinding binding = ActivityArtistDetailBinding.inflate(
+        layoutBinding = ActivityArtistDetailBinding.inflate(
                 getLayoutInflater(),
                 slidingPanelBinding.contentContainer,
                 true);
-
-        songListView = binding.list;
-        artistBorderTheme = binding.imageBorderTheme;
-        artistImage = binding.image;
-        toolbar = binding.toolbar;
-        headerView = binding.header;
-        headerOverlay = binding.headerOverlay;
-
-        durationIconImageView = binding.durationIcon;
-        songCountIconImageView = binding.songCountIcon;
-        albumCountIconImageView = binding.albumCountIcon;
-        durationTextView = binding.durationText;
-        songCountTextView = binding.songCountText;
-        albumCountTextView = binding.albumCountText;
-        titleTextView = binding.title;
 
         return slidingPanelBinding.getRoot();
     }
@@ -176,7 +144,7 @@ public class ArtistDetailActivity
     }
 
     private void initViews() {
-        songListHeader = LayoutInflater.from(this).inflate(R.layout.artist_detail_header, songListView, false);
+        songListHeader = LayoutInflater.from(this).inflate(R.layout.artist_detail_header, layoutBinding.list, false);
         albumRecyclerView = songListHeader.findViewById(R.id.recycler_view);
     }
 
@@ -188,18 +156,18 @@ public class ArtistDetailActivity
 
     private void setUpSongListView() {
         setUpSongListPadding();
-        songListView.setScrollViewCallbacks(observableScrollViewCallbacks);
-        songListView.addHeaderView(songListHeader);
+        layoutBinding.list.setScrollViewCallbacks(observableScrollViewCallbacks);
+        layoutBinding.list.addHeaderView(songListHeader);
 
         songAdapter = new ArtistSongAdapter(this, getArtist().getSongs(), this);
-        songListView.setAdapter(songAdapter);
+        layoutBinding.list.setAdapter(songAdapter);
 
         final View contentView = getWindow().getDecorView().findViewById(android.R.id.content);
         contentView.post(() -> observableScrollViewCallbacks.onScrollChanged(-headerViewHeight, false, false));
     }
 
     private void setUpSongListPadding() {
-        songListView.setPadding(0, headerViewHeight, 0, 0);
+        layoutBinding.list.setPadding(0, headerViewHeight, 0, 0);
     }
 
     private void setUpAlbumRecyclerView() {
@@ -277,14 +245,14 @@ public class ArtistDetailActivity
                 .transition(VinylGlideExtension.getDefaultTransition())
                 .artistOptions(artist)
                 .dontAnimate()
-                .into(new VinylColoredTarget(artistImage) {
+                .into(new VinylColoredTarget(layoutBinding.image) {
                     @Override
                     public void onColorReady(int color) {
                         setColors(color);
                     }
                 });
         forceDownload = false;
-        artistBorderTheme.setRadius(ThemeStyleUtil.getInstance().getAlbumRadiusImage(ArtistDetailActivity.this));
+        layoutBinding.imageBorderTheme.setRadius(ThemeStyleUtil.getInstance().getAlbumRadiusImage(ArtistDetailActivity.this));
     }
 
     @Override
@@ -308,29 +276,27 @@ public class ArtistDetailActivity
 
     private void setColors(int color) {
         toolbarColor = color;
-        headerView.setBackgroundColor(color);
+        layoutBinding.header.setBackgroundColor(color);
 
         setNavigationbarColor(color);
         setTaskDescriptionColor(color);
 
-        toolbar.setBackgroundColor(color);
-        setSupportActionBar(toolbar); // needed to auto readjust the toolbar content color
+        layoutBinding.toolbar.setBackgroundColor(color);
+        setSupportActionBar(layoutBinding.toolbar); // needed to auto readjust the toolbar content color
         setStatusbarColor(color);
 
         final int secondaryTextColor = MaterialValueHelper.getSecondaryTextColor(this, ColorUtil.isColorLight(color));
-        durationIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
-        songCountIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
-        albumCountIconImageView.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
-        durationTextView.setTextColor(secondaryTextColor);
-        songCountTextView.setTextColor(secondaryTextColor);
-        albumCountTextView.setTextColor(secondaryTextColor);
-
-        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
+        layoutBinding.durationIcon.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
+        layoutBinding.songCountIcon.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
+        layoutBinding.albumCountIcon.setColorFilter(secondaryTextColor, PorterDuff.Mode.SRC_IN);
+        layoutBinding.durationText.setTextColor(secondaryTextColor);
+        layoutBinding.songCountText.setTextColor(secondaryTextColor);
+        layoutBinding.albumCountText.setTextColor(secondaryTextColor);
+        layoutBinding.title.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(color)));
     }
 
     private void setUpToolbar() {
-        setSupportActionBar(toolbar);
-        //noinspection ConstantConditions
+        setSupportActionBar(layoutBinding.toolbar);
         getSupportActionBar().setTitle(null);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
@@ -411,7 +377,7 @@ public class ArtistDetailActivity
 
         @ColorInt final int color = getPaletteColor();
         songAdapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubArtist.getId(), menuRes, color, callbacks);
         return cab;
     }
 
@@ -438,10 +404,10 @@ public class ArtistDetailActivity
             loadBiography();
         }
 
-        titleTextView.setText(artist.getName());
-        songCountTextView.setText(MusicUtil.getSongCountString(this, artist.getSongCount()));
-        albumCountTextView.setText(MusicUtil.getAlbumCountString(this, artist.getAlbumCount()));
-        durationTextView.setText(MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(artist.getSongs())));
+        layoutBinding.title.setText(artist.getName());
+        layoutBinding.songCountText.setText(MusicUtil.getSongCountString(this, artist.getSongCount()));
+        layoutBinding.albumCountText.setText(MusicUtil.getAlbumCountString(this, artist.getAlbumCount()));
+        layoutBinding.durationText.setText(MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(artist.getSongs())));
 
         songAdapter.swapDataSet(artist.getSongs());
         albumAdapter.swapDataSet(artist.albums);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/ArtistDetailActivity.java
@@ -377,7 +377,7 @@ public class ArtistDetailActivity
 
         @ColorInt final int color = getPaletteColor();
         songAdapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -24,7 +24,6 @@ import com.poupa.vinylmusicplayer.adapter.song.SongAdapter;
 import com.poupa.vinylmusicplayer.databinding.ActivityGenreDetailBinding;
 import com.poupa.vinylmusicplayer.databinding.SlidingMusicPanelLayoutBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
-import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
@@ -133,7 +132,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this,menu, color, callbacks);
+        cab = CabHolder.openCabImpl(this,menu, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -5,11 +5,9 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
-import androidx.appcompat.widget.Toolbar;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -46,10 +44,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
 
     public static final String EXTRA_GENRE = "extra_genre";
 
-    RecyclerView recyclerView;
-    Toolbar toolbar;
-    TextView empty;
-    TextView titleTextView;
+    private ActivityGenreDetailBinding layoutBinding;
 
     private Genre genre;
 
@@ -79,25 +74,20 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     @Override
     protected View createContentView() {
         SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
-        ActivityGenreDetailBinding binding = ActivityGenreDetailBinding.inflate(
+        layoutBinding = ActivityGenreDetailBinding.inflate(
                 getLayoutInflater(),
                 slidingPanelBinding.contentContainer,
                 true);
-
-        recyclerView = binding.recyclerView;
-        toolbar = binding.toolbar;
-        empty = binding.empty;
-        titleTextView = binding.title;
 
         return slidingPanelBinding.getRoot();
     }
 
     private void setUpRecyclerView() {
-        ViewUtil.setUpFastScrollRecyclerViewColor(this, ((FastScrollRecyclerView) recyclerView), ThemeStore.accentColor(this));
-        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        ViewUtil.setUpFastScrollRecyclerViewColor(this, ((FastScrollRecyclerView) layoutBinding.recyclerView), ThemeStore.accentColor(this));
+        layoutBinding.recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
         adapter = new SongAdapter(this, new ArrayList<>(), R.layout.item_list, false, this);
-        recyclerView.setAdapter(adapter);
+        layoutBinding.recyclerView.setAdapter(adapter);
 
         adapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
             @Override
@@ -109,14 +99,12 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     }
 
     private void setUpToolBar() {
-        toolbar.setBackgroundColor(ThemeStore.primaryColor(this));
-        setSupportActionBar(toolbar);
-        //noinspection ConstantConditions
+        layoutBinding.toolbar.setBackgroundColor(ThemeStore.primaryColor(this));
+        setSupportActionBar(layoutBinding.toolbar);
         getSupportActionBar().setTitle(null);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        titleTextView.setText(genre.getName());
-
-        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(ThemeStore.primaryColor(this))));
+        layoutBinding.title.setText(genre.getName());
+        layoutBinding.title.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(ThemeStore.primaryColor(this))));
     }
 
     @Override
@@ -145,7 +133,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, menu, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubGenre.getId(), menu, color, callbacks);
         return cab;
     }
 
@@ -153,7 +141,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     public void onBackPressed() {
         if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
         else {
-            recyclerView.stopScroll();
+            layoutBinding.recyclerView.stopScroll();
             super.onBackPressed();
         }
     }
@@ -175,17 +163,14 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     }
 
     private void checkIsEmpty() {
-        empty.setVisibility(
+        layoutBinding.empty.setVisibility(
                 adapter.getItemCount() == 0 ? View.VISIBLE : View.GONE
         );
     }
 
     @Override
     protected void onDestroy() {
-        if (recyclerView != null) {
-            recyclerView.setAdapter(null);
-            recyclerView = null;
-        }
+        layoutBinding.recyclerView.setAdapter(null);
 
         if (wrappedAdapter != null) {
             WrapperAdapterUtils.releaseAll(wrappedAdapter);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -7,6 +7,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.loader.app.LoaderManager;
@@ -14,7 +15,8 @@ import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.kabouzeid.appthemehelper.util.ColorUtil;
@@ -25,6 +27,7 @@ import com.poupa.vinylmusicplayer.databinding.ActivityGenreDetailBinding;
 import com.poupa.vinylmusicplayer.databinding.SlidingMusicPanelLayoutBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
+import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.loader.GenreLoader;
@@ -50,7 +53,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
 
     private Genre genre;
 
-    private MaterialCab cab;
+    private AttachedCab cab;
     private SongAdapter adapter;
 
     private RecyclerView.Adapter wrappedAdapter;
@@ -137,20 +140,18 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
 
     @NonNull
     @Override
-    public MaterialCab openCab(final int menu, final MaterialCab.Callback callback) {
-        if (cab != null && cab.isActive()) cab.finish();
-        adapter.setColor(ThemeStore.primaryColor(this));
-        cab = MenuHelper.setOverflowMenu(this, menu, ThemeStore.primaryColor(this))
-                .start(callback);
+    public AttachedCab openCab(final int menu, final CabCallbacks callbacks) {
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
 
-        MenuHelper.decorateDestructiveItems(cab.getMenu(), this);
-
+        @ColorInt final int color = ThemeStore.primaryColor(this);
+        adapter.setColor(color);
+        cab = MenuHelper.createAndOpenCab(this, menu, color, callbacks);
         return cab;
     }
 
     @Override
     public void onBackPressed() {
-        if (cab != null && cab.isActive()) cab.finish();
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
         else {
             recyclerView.stopScroll();
             super.onBackPressed();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -129,11 +129,11 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     @NonNull
     @Override
     public AttachedCab openCab(final int menu, final CabCallbacks callbacks) {
-        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
+        AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubGenre.getId(), menu, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menu, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/GenreDetailActivity.java
@@ -133,7 +133,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menu, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this,menu, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/MainActivity.java
@@ -115,7 +115,7 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
                 break;
             case FOLDERS:
                 navigationView.setCheckedItem(R.id.nav_folders);
-                setCurrentFragment(FoldersFragment.newInstance(this));
+                setCurrentFragment(FoldersFragment.newInstance());
                 break;
         }
     }

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -7,6 +7,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.loader.app.LoaderManager;
@@ -14,7 +15,8 @@ import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.h6ah4i.android.widget.advrecyclerview.animator.GeneralItemAnimator;
 import com.h6ah4i.android.widget.advrecyclerview.animator.RefactoredDefaultItemAnimator;
 import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager;
@@ -31,6 +33,7 @@ import com.poupa.vinylmusicplayer.databinding.SlidingMusicPanelLayoutBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.PlaylistMenuHelper;
+import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.loader.PlaylistLoader;
@@ -59,7 +62,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
 
     private Playlist playlist;
 
-    private MaterialCab cab;
+    private AttachedCab cab;
     private SongAdapter adapter;
 
     private RecyclerView.Adapter wrappedAdapter;
@@ -168,20 +171,18 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
 
     @NonNull
     @Override
-    public MaterialCab openCab(final int menu, final MaterialCab.Callback callback) {
-        if (cab != null && cab.isActive()) cab.finish();
-        adapter.setColor(ThemeStore.primaryColor(this));
-        cab = MenuHelper.setOverflowMenu(this, menu, ThemeStore.primaryColor(this))
-                .start(callback);
+    public AttachedCab openCab(final int menu, final CabCallbacks callbacks) {
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
 
-        MenuHelper.decorateDestructiveItems(cab.getMenu(), this);
-
+        @ColorInt final int color = ThemeStore.primaryColor(this);
+        adapter.setColor(color);
+        cab = MenuHelper.createAndOpenCab(this, menu, color, callbacks);
         return cab;
     }
 
     @Override
     public void onBackPressed() {
-        if (cab != null && cab.isActive()) cab.finish();
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
         else {
             recyclerView.stopScroll();
             super.onBackPressed();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -173,7 +173,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, menu, color, callbacks);
+        cab = CabHolder.openCabImpl(this, menu, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -173,7 +173,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menu, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, menu, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -5,11 +5,9 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
-import androidx.appcompat.widget.Toolbar;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -55,10 +53,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     @NonNull
     public static final String EXTRA_PLAYLIST = "extra_playlist";
 
-    private RecyclerView recyclerView;
-    private Toolbar toolbar;
-    private TextView empty;
-    private TextView titleTextView;
+    private ActivityPlaylistDetailBinding layoutBinding;
 
     private Playlist playlist;
 
@@ -89,41 +84,44 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     @Override
     protected View createContentView() {
         final SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
-        final ActivityPlaylistDetailBinding binding = ActivityPlaylistDetailBinding.inflate(
+        layoutBinding = ActivityPlaylistDetailBinding.inflate(
                 getLayoutInflater(),
                 slidingPanelBinding.contentContainer,
                 true);
-
-        recyclerView = binding.recyclerView;
-        toolbar = binding.toolbar;
-        empty = binding.empty;
-        titleTextView = binding.title;
 
         return slidingPanelBinding.getRoot();
     }
 
     private void setUpRecyclerView() {
-        ViewUtil.setUpFastScrollRecyclerViewColor(this, ((FastScrollRecyclerView) recyclerView), ThemeStore.accentColor(this));
-        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        ViewUtil.setUpFastScrollRecyclerViewColor(
+                this,
+                ((FastScrollRecyclerView) layoutBinding.recyclerView),
+                ThemeStore.accentColor(this));
+        layoutBinding.recyclerView.setLayoutManager(new LinearLayoutManager(this));
         if (playlist instanceof AbsCustomPlaylist) {
             adapter = new PlaylistSongAdapter(this, new ArrayList<>(), false, this);
-            recyclerView.setAdapter(adapter);
+            layoutBinding.recyclerView.setAdapter(adapter);
         } else {
             recyclerViewDragDropManager = new RecyclerViewDragDropManager();
             final GeneralItemAnimator animator = new RefactoredDefaultItemAnimator();
-            adapter = new OrderablePlaylistSongAdapter(this, new ArrayList<>(), false, this, (fromPosition, toPosition) -> {
-                if (PlaylistsUtil.moveItem(PlaylistDetailActivity.this, playlist.id, fromPosition, toPosition)) {
-                    Song song = adapter.getDataSet().remove(fromPosition);
-                    adapter.getDataSet().add(toPosition, song);
-                    adapter.notifyItemMoved(fromPosition, toPosition);
-                }
-            });
+            adapter = new OrderablePlaylistSongAdapter(
+                    this,
+                    new ArrayList<>(),
+                    false,
+                    this,
+                    (fromPosition, toPosition) -> {
+                        if (PlaylistsUtil.moveItem(PlaylistDetailActivity.this, playlist.id, fromPosition, toPosition)) {
+                            Song song = adapter.getDataSet().remove(fromPosition);
+                            adapter.getDataSet().add(toPosition, song);
+                            adapter.notifyItemMoved(fromPosition, toPosition);
+                        }
+                    });
             wrappedAdapter = recyclerViewDragDropManager.createWrappedAdapter(adapter);
 
-            recyclerView.setAdapter(wrappedAdapter);
-            recyclerView.setItemAnimator(animator);
+            layoutBinding.recyclerView.setAdapter(wrappedAdapter);
+            layoutBinding.recyclerView.setItemAnimator(animator);
 
-            recyclerViewDragDropManager.attachRecyclerView(recyclerView);
+            recyclerViewDragDropManager.attachRecyclerView(layoutBinding.recyclerView);
         }
 
         adapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
@@ -136,13 +134,12 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     }
 
     private void setUpToolbar() {
-        toolbar.setBackgroundColor(ThemeStore.primaryColor(this));
-        setSupportActionBar(toolbar);
+        layoutBinding.toolbar.setBackgroundColor(ThemeStore.primaryColor(this));
+        setSupportActionBar(layoutBinding.toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         setToolbarTitle(null);
-        titleTextView.setText(playlist.name);
-
-        titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(ThemeStore.primaryColor(this))));
+        layoutBinding.title.setText(playlist.name);
+        layoutBinding.title.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(ThemeStore.primaryColor(this))));
     }
 
     private void setToolbarTitle(final String title) {
@@ -176,7 +173,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, menu, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubPlaylist.getId(), menu, color, callbacks);
         return cab;
     }
 
@@ -184,7 +181,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     public void onBackPressed() {
         if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
         else {
-            recyclerView.stopScroll();
+            layoutBinding.recyclerView.stopScroll();
             super.onBackPressed();
         }
     }
@@ -229,7 +226,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     }
 
     private void checkIsEmpty() {
-        empty.setVisibility(
+        layoutBinding.empty.setVisibility(
                 adapter.getItemCount() == 0 ? View.VISIBLE : View.GONE
         );
     }
@@ -249,11 +246,8 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
             recyclerViewDragDropManager = null;
         }
 
-        if (recyclerView != null) {
-            recyclerView.setItemAnimator(null);
-            recyclerView.setAdapter(null);
-            recyclerView = null;
-        }
+        layoutBinding.recyclerView.setItemAnimator(null);
+        layoutBinding.recyclerView.setAdapter(null);
 
         if (wrappedAdapter != null) {
             WrapperAdapterUtils.releaseAll(wrappedAdapter);

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -169,11 +169,11 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     @NonNull
     @Override
     public AttachedCab openCab(final int menu, final CabCallbacks callbacks) {
-        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
+        AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = ThemeStore.primaryColor(this);
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabStubPlaylist.getId(), menu, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(this, layoutBinding.cabHolder.getId(), menu, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/PlaylistDetailActivity.java
@@ -55,10 +55,10 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     @NonNull
     public static final String EXTRA_PLAYLIST = "extra_playlist";
 
-    RecyclerView recyclerView;
-    Toolbar toolbar;
-    TextView empty;
-    TextView titleTextView;
+    private RecyclerView recyclerView;
+    private Toolbar toolbar;
+    private TextView empty;
+    private TextView titleTextView;
 
     private Playlist playlist;
 
@@ -69,7 +69,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     private RecyclerViewDragDropManager recyclerViewDragDropManager;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setDrawUnderStatusbar();
 
@@ -88,8 +88,8 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
 
     @Override
     protected View createContentView() {
-        SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
-        ActivityPlaylistDetailBinding binding = ActivityPlaylistDetailBinding.inflate(
+        final SlidingMusicPanelLayoutBinding slidingPanelBinding = createSlidingMusicPanel();
+        final ActivityPlaylistDetailBinding binding = ActivityPlaylistDetailBinding.inflate(
                 getLayoutInflater(),
                 slidingPanelBinding.contentContainer,
                 true);
@@ -145,19 +145,19 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
         titleTextView.setTextColor(MaterialValueHelper.getPrimaryTextColor(this, ColorUtil.isColorLight(ThemeStore.primaryColor(this))));
     }
 
-    private void setToolbarTitle(String title) {
+    private void setToolbarTitle(final String title) {
         getSupportActionBar().setTitle(title);
     }
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(final Menu menu) {
         getMenuInflater().inflate(playlist instanceof AbsCustomPlaylist ? R.menu.menu_smart_playlist_detail : R.menu.menu_playlist_detail, menu);
         MenuHelper.decorateDestructiveItems(menu, this);
         return super.onCreateOptionsMenu(menu);
     }
 
     @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
         final int id = item.getItemId();
         if (id == R.id.action_shuffle_playlist) {
             MusicPlayerRemote.openAndShuffleQueue(adapter.getDataSet(), true);
@@ -266,20 +266,22 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
 
     @Override
     @NonNull
-    public Loader<ArrayList<Song>> onCreateLoader(int id, Bundle args) {
+    public Loader<ArrayList<Song>> onCreateLoader(int id, final Bundle args) {
         return new AsyncPlaylistSongLoader(this, playlist);
     }
 
     @Override
-    public void onLoadFinished(@NonNull Loader<ArrayList<Song>> loader, ArrayList<Song> data) {
-        if (adapter != null)
+    public void onLoadFinished(@NonNull final Loader<ArrayList<Song>> loader, final ArrayList<Song> data) {
+        if (adapter != null) {
             adapter.swapDataSet(data);
+        }
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader<ArrayList<Song>> loader) {
-        if (adapter != null)
+    public void onLoaderReset(@NonNull final Loader<ArrayList<Song>> loader) {
+        if (adapter != null) {
             adapter.swapDataSet(new ArrayList<>());
+        }
     }
 
     @Override
@@ -290,11 +292,12 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     private static class AsyncPlaylistSongLoader extends WrappedAsyncTaskLoader<ArrayList<Song>> {
         private final Playlist playlist;
 
-        public AsyncPlaylistSongLoader(Context context, Playlist playlist) {
+        AsyncPlaylistSongLoader(final Context context, final Playlist playlist) {
             super(context);
             this.playlist = playlist;
         }
 
+        @NonNull
         @Override
         public ArrayList<Song> loadInBackground() {
             return playlist.getSongs(getContext());

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/SettingsActivity.java
@@ -241,9 +241,9 @@ public class SettingsActivity extends AbsBaseActivity implements ColorChooserDia
                 });
             }
 
-            final Preference themeStyle = findPreference("theme_style");
+            final Preference themeStyle = findPreference(PreferenceUtil.THEME_STYLE);
             themeStyle.setOnPreferenceChangeListener((preference, o) -> {
-                ThemeStyleUtil.updateInstance(PreferenceUtil.getThemeStyleFromPrefValue((String) o));
+                ThemeStyleUtil.updateInstance((String) o);
                 if (getActivity() != null) {
                     ThemeStore.markChanged(getActivity());
                 }
@@ -407,7 +407,7 @@ public class SettingsActivity extends AbsBaseActivity implements ColorChooserDia
                     break;
                 case PreferenceUtil.CLASSIC_NOTIFICATION:
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        findPreference("colored_notification").setEnabled(sharedPreferences.getBoolean(key, false));
+                        findPreference(PreferenceUtil.COLORED_NOTIFICATION).setEnabled(sharedPreferences.getBoolean(key, false));
                     }
                     break;
                 case PreferenceUtil.RG_SOURCE_MODE_V2:

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -82,7 +82,7 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
     boolean isInNoImageMode;
     private final SimpleObservableScrollViewCallbacks observableScrollViewCallbacks = new SimpleObservableScrollViewCallbacks() {
         @Override
-        public void onScrollChanged(int scrollY, boolean b, boolean b2) {
+        public void onScrollChanged(int scrollY, boolean firstScroll, boolean dragging) {
             float alpha;
             if (!isInNoImageMode) {
                 alpha = 1 - (float) Math.max(0, headerVariableSpace - scrollY) / headerVariableSpace;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -71,16 +71,16 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
 
     private static final int LOADER_ID = LoaderIds.FOLDERS_FRAGMENT;
 
-    protected static final String PATH = "path";
-    protected static final String CRUMBS = "crumbs";
+    private static final String PATH = "path";
+    private static final String CRUMBS = "crumbs";
 
-    CoordinatorLayout coordinatorLayout;
-    View container;
-    View empty;
-    Toolbar toolbar;
-    BreadCrumbLayout breadCrumbs;
-    AppBarLayout appbar;
-    FastScrollRecyclerView recyclerView;
+    private CoordinatorLayout coordinatorLayout;
+    private View container;
+    private View empty;
+    private Toolbar toolbar;
+    private BreadCrumbLayout breadCrumbs;
+    private AppBarLayout appbar;
+    private FastScrollRecyclerView recyclerView;
 
     private SongFileAdapter adapter;
     private AttachedCab cab;
@@ -88,20 +88,20 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     public FoldersFragment() {
     }
 
-    public static FoldersFragment newInstance(Context context) {
+    public static FoldersFragment newInstance() {
         return newInstance(PreferenceUtil.getInstance().getStartDirectory());
     }
 
-    public static FoldersFragment newInstance(File directory) {
-        FoldersFragment frag = new FoldersFragment();
-        Bundle b = new Bundle();
-        b.putSerializable(PATH, directory);
-        frag.setArguments(b);
+    public static FoldersFragment newInstance(final File directory) {
+        final FoldersFragment frag = new FoldersFragment();
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(PATH, directory);
+        frag.setArguments(bundle);
         return frag;
     }
 
-    public void setCrumb(BreadCrumbLayout.Crumb crumb, boolean addToHistory) {
-        if (crumb == null) return;
+    private void setCrumb(final BreadCrumbLayout.Crumb crumb, boolean addToHistory) {
+        if (crumb == null) {return;}
         saveScrollPosition();
         breadCrumbs.setActiveOrAdd(crumb, false);
         if (addToHistory) {
@@ -111,7 +111,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     private void saveScrollPosition() {
-        BreadCrumbLayout.Crumb crumb = getActiveCrumb();
+        final BreadCrumbLayout.Crumb crumb = getActiveCrumb();
         if (crumb != null) {
             crumb.setScrollPosition(((LinearLayoutManager) recyclerView.getLayoutManager()).findFirstVisibleItemPosition());
         }
@@ -123,12 +123,12 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onSaveInstanceState(@NonNull Bundle outState) {
+    public void onSaveInstanceState(@NonNull final Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelable(CRUMBS, breadCrumbs.getStateWrapper());
     }
 
-    private void restoreBreadcrumb(Bundle savedInstanceState) {
+    private void restoreBreadcrumb(final Bundle savedInstanceState) {
         if (savedInstanceState == null) {
             setCrumb(new BreadCrumbLayout.Crumb(FileUtil.safeGetCanonicalFile((File) getArguments().getSerializable(PATH))), true);
         } else {
@@ -138,8 +138,8 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        FragmentFolderBinding binding = FragmentFolderBinding.inflate(inflater, container, false);
+    public View onCreateView(@NonNull final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
+        final FragmentFolderBinding binding = FragmentFolderBinding.inflate(inflater, container, false);
         coordinatorLayout = binding.coordinatorLayout;
         this.container = binding.container;
         empty = binding.empty;
@@ -154,7 +154,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         getMainActivity().setStatusbarColorAuto();
         getMainActivity().setNavigationbarColorAuto();
         getMainActivity().setTaskDescriptionColorAuto();
@@ -167,17 +167,17 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     private void setUpAppbarColor() {
-        int primaryColor = ThemeStore.primaryColor(getActivity());
+        final int primaryColor = ThemeStore.primaryColor(requireActivity());
         appbar.setBackgroundColor(primaryColor);
         toolbar.setBackgroundColor(primaryColor);
         breadCrumbs.setBackgroundColor(primaryColor);
-        breadCrumbs.setActivatedContentColor(ToolbarContentTintHelper.toolbarTitleColor(getActivity(), primaryColor));
-        breadCrumbs.setDeactivatedContentColor(ToolbarContentTintHelper.toolbarSubtitleColor(getActivity(), primaryColor));
+        breadCrumbs.setActivatedContentColor(ToolbarContentTintHelper.toolbarTitleColor(requireActivity(), primaryColor));
+        breadCrumbs.setDeactivatedContentColor(ToolbarContentTintHelper.toolbarSubtitleColor(requireActivity(), primaryColor));
     }
 
     private void setUpToolbar() {
         toolbar.setNavigationIcon(R.drawable.ic_menu_white_24dp);
-        getActivity().setTitle(R.string.app_name);
+        requireActivity().setTitle(R.string.app_name);
         getMainActivity().setSupportActionBar(toolbar);
     }
 
@@ -186,7 +186,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     private void setUpRecyclerView() {
-        ViewUtil.setUpFastScrollRecyclerViewColor(getActivity(), recyclerView, ThemeStore.accentColor(getActivity()));
+        ViewUtil.setUpFastScrollRecyclerViewColor(getActivity(), recyclerView, ThemeStore.accentColor(requireActivity()));
 
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
 
@@ -243,16 +243,16 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull final Menu menu, @NonNull final MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
         inflater.inflate(R.menu.menu_folders, menu);
-        ToolbarContentTintHelper.handleOnCreateOptionsMenu(getActivity(), toolbar, menu, ATHToolbarActivity.getToolbarBackgroundColor(toolbar));
+        ToolbarContentTintHelper.handleOnCreateOptionsMenu(requireActivity(), toolbar, menu, ATHToolbarActivity.getToolbarBackgroundColor(toolbar));
     }
 
     @Override
-    public void onPrepareOptionsMenu(@NonNull Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull final Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        ToolbarContentTintHelper.handleOnPrepareOptionsMenu(getActivity(), toolbar);
+        ToolbarContentTintHelper.handleOnPrepareOptionsMenu(requireActivity(), toolbar);
     }
 
     public static final FileFilter AUDIO_FILE_FILTER = file -> !file.isHidden() && (file.isDirectory() ||
@@ -261,17 +261,17 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
                         FileUtil.fileIsMimeType(file, "application/ogg", MimeTypeMap.getSingleton()));
 
     @Override
-    public void onCrumbSelection(BreadCrumbLayout.Crumb crumb, int index) {
+    public void onCrumbSelection(final BreadCrumbLayout.Crumb crumb, int index) {
         setCrumb(crumb, true);
     }
 
     public static File getDefaultStartDirectory() {
-        File musicDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC);
-        File startFolder;
+        final File musicDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC);
+        final File startFolder;
         if (musicDir.exists() && musicDir.isDirectory()) {
             startFolder = musicDir;
         } else {
-            File externalStorage = Environment.getExternalStorageDirectory();
+            final File externalStorage = Environment.getExternalStorageDirectory();
             if (externalStorage.exists() && externalStorage.isDirectory()) {
                 startFolder = externalStorage;
             } else {
@@ -282,16 +282,16 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
         final int itemId = item.getItemId();
         if (itemId == R.id.action_go_to_start_directory) {
             setCrumb(new BreadCrumbLayout.Crumb(FileUtil.safeGetCanonicalFile(PreferenceUtil.getInstance().getStartDirectory())), true);
             return true;
         } else if (itemId == R.id.action_scan) {
-            BreadCrumbLayout.Crumb crumb = getActiveCrumb();
+            final BreadCrumbLayout.Crumb crumb = getActiveCrumb();
             if (crumb != null) {
-                if (((MainActivity) getActivity()).isNotScanning()) {
-                    ((MainActivity) getActivity()).setScanning(true);
+                if (((MainActivity) requireActivity()).isNotScanning()) {
+                    ((MainActivity) requireActivity()).setScanning(true);
                     new ListPathsAsyncTask(getActivity(), this::scanPaths).execute(new ListPathsAsyncTask.LoadingInfo(crumb.getFile(), AUDIO_FILE_FILTER));
                 }
 
@@ -302,15 +302,16 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onFileSelected(File file) {
+    public void onFileSelected(final File file) {
         final File canonicalFile = FileUtil.safeGetCanonicalFile(file); // important as we compare the path value later
         if (canonicalFile.isDirectory()) {
             setCrumb(new BreadCrumbLayout.Crumb(canonicalFile), true);
         } else {
-            FileFilter fileFilter = pathname -> !pathname.isDirectory() && AUDIO_FILE_FILTER.accept(pathname);
+            final FileFilter fileFilter = pathname -> !pathname.isDirectory() && AUDIO_FILE_FILTER.accept(pathname);
             new ListSongsAsyncTask(getActivity(), null, (songs, extra) -> {
                 int startIndex = -1;
-                for (int i = 0; i < songs.size(); i++) {
+                int size = songs.size();
+                for (int i = 0; i < size; i++) {
                     if (canonicalFile.getPath().equals(songs.get(i).data)) {
                         startIndex = i;
                         break;
@@ -321,7 +322,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
                 } else {
                     Snackbar.make(coordinatorLayout, Html.fromHtml(String.format(getString(R.string.not_listed_in_media_store), canonicalFile.getName())), Snackbar.LENGTH_LONG)
                             .setAction(R.string.action_scan, v -> scanPaths(new String[]{canonicalFile.getPath()}))
-                            .setActionTextColor(ThemeStore.accentColor(getActivity()))
+                            .setActionTextColor(ThemeStore.accentColor(requireActivity()))
                             .show();
                 }
             }).execute(new ListSongsAsyncTask.LoadingInfo(toList(canonicalFile.getParentFile()), fileFilter, getFileComparator()));
@@ -329,29 +330,30 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onMultipleItemAction(MenuItem item, ArrayList<File> files) {
+    public void onMultipleItemAction(final MenuItem item, final ArrayList<File> files) {
         final int itemId = item.getItemId();
         new ListSongsAsyncTask(getActivity(), null, (songs, extra) -> {
             if (!songs.isEmpty()) {
-                SongsMenuHelper.handleMenuClick(getActivity(), songs, itemId);
+                SongsMenuHelper.handleMenuClick(requireActivity(), songs, itemId);
             }
             if (songs.size() != files.size()) {
                 Snackbar.make(coordinatorLayout, R.string.some_files_are_not_listed_in_the_media_store, Snackbar.LENGTH_LONG)
                         .setAction(R.string.action_scan, v -> {
-                            String[] paths = new String[files.size()];
-                            for (int i = 0; i < files.size(); i++) {
+                            final int size = files.size();
+                            final String[] paths = new String[size];
+                            for (int i = 0; i < size; i++) {
                                 paths[i] = FileUtil.safeGetCanonicalPath(files.get(i));
                             }
                             scanPaths(paths);
                         })
-                        .setActionTextColor(ThemeStore.accentColor(getActivity()))
+                        .setActionTextColor(ThemeStore.accentColor(requireActivity()))
                         .show();
             }
         }).execute(new ListSongsAsyncTask.LoadingInfo(files, AUDIO_FILE_FILTER, getFileComparator()));
     }
 
-    private ArrayList<File> toList(File file) {
-        ArrayList<File> files = new ArrayList<>(1);
+    private static ArrayList<File> toList(final File file) {
+        final ArrayList<File> files = new ArrayList<>(1);
         files.add(file);
         return files;
     }
@@ -362,8 +364,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         } else if (!lhs.isDirectory() && rhs.isDirectory()) {
             return 1;
         } else {
-            return lhs.getAbsolutePath().compareToIgnoreCase
-                    (rhs.getAbsolutePath());
+            return lhs.getAbsolutePath().compareToIgnoreCase(rhs.getAbsolutePath());
         }
     };
 
@@ -372,8 +373,8 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onFileMenuClicked(final File file, View view) {
-        PopupMenu popupMenu = new PopupMenu(getActivity(), view);
+    public void onFileMenuClicked(final File file, final View view) {
+        final PopupMenu popupMenu = new PopupMenu(getActivity(), view);
         if (file.isDirectory()) {
             popupMenu.inflate(R.menu.menu_item_directory);
             popupMenu.setOnMenuItemClickListener(item -> {
@@ -381,7 +382,8 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
                 if (itemId == R.id.action_play_next
                         || itemId == R.id.action_add_to_current_playing
                         || itemId == R.id.action_add_to_playlist
-                        || itemId == R.id.action_delete_from_device) {
+                        || itemId == R.id.action_delete_from_device)
+                {
                     new ListSongsAsyncTask(getActivity(), null, (songs, extra) -> {
                         if (!songs.isEmpty()) {
                             SongsMenuHelper.handleMenuClick(getActivity(), songs, itemId);
@@ -394,13 +396,13 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
                     
                     // Rescan if whitelist enabled
                     if (PreferenceUtil.getInstance().getWhitelistEnabled()) {
-                        getContext().sendBroadcast(new Intent(MusicService.MEDIA_STORE_CHANGED));
+                        requireContext().sendBroadcast(new Intent(MusicService.MEDIA_STORE_CHANGED));
                     }  
                   
                     return true;
                 } else if (itemId == R.id.action_scan) {
-                    if (((MainActivity) getActivity()).isNotScanning()) {
-                        ((MainActivity) getActivity()).setScanning(true);
+                    if (((MainActivity) requireActivity()).isNotScanning()) {
+                        ((MainActivity) requireActivity()).setScanning(true);
                         new ListPathsAsyncTask(getActivity(), this::scanPaths).execute(new ListPathsAsyncTask.LoadingInfo(file, AUDIO_FILE_FILTER));
                     }
 
@@ -412,14 +414,24 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
             popupMenu.inflate(R.menu.menu_item_file);
             popupMenu.setOnMenuItemClickListener(item -> {
                 final int itemId = item.getItemId();
-                if (itemId == R.id.action_play_next || itemId == R.id.action_add_to_current_playing || itemId == R.id.action_add_to_playlist || itemId == R.id.action_go_to_album || itemId == R.id.action_go_to_artist || itemId == R.id.action_share || itemId == R.id.action_tag_editor || itemId == R.id.action_details || itemId == R.id.action_set_as_ringtone || itemId == R.id.action_delete_from_device) {
+                if (itemId == R.id.action_play_next
+                        || itemId == R.id.action_add_to_current_playing
+                        || itemId == R.id.action_add_to_playlist
+                        || itemId == R.id.action_go_to_album
+                        || itemId == R.id.action_go_to_artist
+                        || itemId == R.id.action_share
+                        || itemId == R.id.action_tag_editor
+                        || itemId == R.id.action_details
+                        || itemId == R.id.action_set_as_ringtone
+                        || itemId == R.id.action_delete_from_device)
+                {
                     new ListSongsAsyncTask(getActivity(), null, (songs, extra) -> {
                         if (!songs.isEmpty()) {
-                            SongMenuHelper.handleMenuClick(getActivity(), songs.get(0), itemId);
+                            SongMenuHelper.handleMenuClick(requireActivity(), songs.get(0), itemId);
                         } else {
                             Snackbar.make(coordinatorLayout, Html.fromHtml(String.format(getString(R.string.not_listed_in_media_store), file.getName())), Snackbar.LENGTH_LONG)
                                     .setAction(R.string.action_scan, v -> scanPaths(new String[]{FileUtil.safeGetCanonicalPath(file)}))
-                                    .setActionTextColor(ThemeStore.accentColor(getActivity()))
+                                    .setActionTextColor(ThemeStore.accentColor(requireActivity()))
                                     .show();
                         }
                     }).execute(new ListSongsAsyncTask.LoadingInfo(toList(file), AUDIO_FILE_FILTER, getFileComparator()));
@@ -435,7 +447,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onOffsetChanged(AppBarLayout appBarLayout, int verticalOffset) {
+    public void onOffsetChanged(final AppBarLayout appBarLayout, int verticalOffset) {
         container.setPadding(container.getPaddingLeft(), container.getPaddingTop(), container.getPaddingRight(), appbar.getTotalScrollRange() + verticalOffset);
     }
 
@@ -445,8 +457,8 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
     }
 
-    private void scanPaths(@Nullable String[] toBeScanned) {
-        if (getActivity() == null) return;
+    private void scanPaths(@Nullable final String[] toBeScanned) {
+        if (getActivity() == null) {return;}
         if (toBeScanned == null || toBeScanned.length < 1) {
             Toast.makeText(getActivity(), R.string.nothing_to_scan, Toast.LENGTH_SHORT).show();
         } else {
@@ -454,9 +466,9 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
     }
 
-    private void updateAdapter(@NonNull List<File> files) {
+    private void updateAdapter(@NonNull final List<File> files) {
         adapter.swapDataSet(files);
-        BreadCrumbLayout.Crumb crumb = getActiveCrumb();
+        final BreadCrumbLayout.Crumb crumb = getActiveCrumb();
         if (crumb != null && recyclerView != null) {
             ((LinearLayoutManager) recyclerView.getLayoutManager()).scrollToPositionWithOffset(crumb.getScrollPosition(), 0);
         }
@@ -464,40 +476,40 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
 
     @Override
     @NonNull
-    public Loader<List<File>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<File>> onCreateLoader(int id, final Bundle args) {
         return new AsyncFileLoader(this);
     }
 
     @Override
-    public void onLoadFinished(@NonNull Loader<List<File>> loader, List<File> data) {
+    public void onLoadFinished(@NonNull final Loader<List<File>> loader, final List<File> data) {
         updateAdapter(data);
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader<List<File>> loader) {
+    public void onLoaderReset(@NonNull final Loader<List<File>> loader) {
         updateAdapter(new LinkedList<>());
     }
 
     private static class AsyncFileLoader extends WrappedAsyncTaskLoader<List<File>> {
         private final WeakReference<FoldersFragment> fragmentWeakReference;
 
-        public AsyncFileLoader(FoldersFragment foldersFragment) {
+        public AsyncFileLoader(@NonNull final FoldersFragment foldersFragment) {
             super(foldersFragment.getActivity());
             fragmentWeakReference = new WeakReference<>(foldersFragment);
         }
 
         @Override
         public List<File> loadInBackground() {
-            FoldersFragment foldersFragment = fragmentWeakReference.get();
+            final FoldersFragment foldersFragment = fragmentWeakReference.get();
             File directory = null;
             if (foldersFragment != null) {
-                BreadCrumbLayout.Crumb crumb = foldersFragment.getActiveCrumb();
+                final BreadCrumbLayout.Crumb crumb = foldersFragment.getActiveCrumb();
                 if (crumb != null) {
                     directory = crumb.getFile();
                 }
             }
             if (directory != null) {
-                List<File> files = FileUtil.listFiles(directory, AUDIO_FILE_FILTER);
+                final List<File> files = FileUtil.listFiles(directory, AUDIO_FILE_FILTER);
                 Collections.sort(files, foldersFragment.getFileComparator());
                 return files;
             } else {
@@ -511,7 +523,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         private final WeakReference<OnSongsListedCallback> callbackWeakReference;
         private final Object extra;
 
-        public ListSongsAsyncTask(Context context, Object extra, OnSongsListedCallback callback) {
+        ListSongsAsyncTask(final Context context, final Object extra, final OnSongsListedCallback callback) {
             super(context, 500);
             this.extra = extra;
             contextWeakReference = new WeakReference<>(context);
@@ -525,20 +537,22 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
             checkContextReference();
         }
 
+        @Nullable
         @Override
-        protected ArrayList<Song> doInBackground(LoadingInfo... params) {
+        protected ArrayList<Song> doInBackground(final LoadingInfo... params) {
             try {
-                LoadingInfo info = params[0];
-                List<File> files = FileUtil.listFilesDeep(info.files, info.fileFilter);
+                final LoadingInfo info = params[0];
+                final List<File> files = FileUtil.listFilesDeep(info.files, info.fileFilter);
 
                 if (isCancelled() || checkContextReference() == null || checkCallbackReference() == null)
                     return null;
 
                 Collections.sort(files, info.fileComparator);
 
-                Context context = checkContextReference();
-                if (isCancelled() || context == null || checkCallbackReference() == null)
+                final Context context = checkContextReference();
+                if (isCancelled() || context == null || checkCallbackReference() == null) {
                     return null;
+                }
 
                 return FileUtil.matchFilesWithMediaStore(files);
             } catch (Exception e) {
@@ -549,15 +563,16 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
 
         @Override
-        protected void onPostExecute(ArrayList<Song> songs) {
+        protected void onPostExecute(final ArrayList<Song> songs) {
             super.onPostExecute(songs);
-            OnSongsListedCallback callback = checkCallbackReference();
-            if (songs != null && callback != null)
+            final OnSongsListedCallback callback = checkCallbackReference();
+            if (songs != null && callback != null) {
                 callback.onSongsListed(songs, extra);
+            }
         }
 
         private Context checkContextReference() {
-            Context context = contextWeakReference.get();
+            final Context context = contextWeakReference.get();
             if (context == null) {
                 cancel(false);
             }
@@ -565,7 +580,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
 
         private OnSongsListedCallback checkCallbackReference() {
-            OnSongsListedCallback callback = callbackWeakReference.get();
+            final OnSongsListedCallback callback = callbackWeakReference.get();
             if (callback == null) {
                 cancel(false);
             }
@@ -573,11 +588,11 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
 
         public static class LoadingInfo {
-            public final Comparator<File> fileComparator;
-            public final FileFilter fileFilter;
+            final Comparator<File> fileComparator;
+            final FileFilter fileFilter;
             public final List<File> files;
 
-            public LoadingInfo(@NonNull List<File> files, @NonNull FileFilter fileFilter, @NonNull Comparator<File> fileComparator) {
+            LoadingInfo(@NonNull final List<File> files, @NonNull final FileFilter fileFilter, @NonNull final Comparator<File> fileComparator) {
                 this.fileComparator = fileComparator;
                 this.fileFilter = fileFilter;
                 this.files = files;
@@ -592,7 +607,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     public static class ListPathsAsyncTask extends ListingFilesDialogAsyncTask<ListPathsAsyncTask.LoadingInfo, String, String[]> {
         private final OnPathsListedCallback onPathsListedCallback;
 
-        public ListPathsAsyncTask(Context context, OnPathsListedCallback callback) {
+        public ListPathsAsyncTask(final Context context, final OnPathsListedCallback callback) {
             super(context, 500);
             this.onPathsListedCallback = callback;
         }
@@ -604,25 +619,26 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
 
         @Override
-        protected String[] doInBackground(LoadingInfo... params) {
+        protected String[] doInBackground(final LoadingInfo... params) {
             try {
                 if (isCancelled() || !isContextStillInMemory()) {
                     return null;
                 }
 
-                LoadingInfo info = params[0];
+                final LoadingInfo info = params[0];
 
                 final String[] paths;
 
                 if (info.file.isDirectory()) {
-                    List<File> files = FileUtil.listFilesDeep(info.file, info.fileFilter);
+                    final List<File> files = FileUtil.listFilesDeep(info.file, info.fileFilter);
 
                     if (isCancelled() || !isContextStillInMemory()) {
                         return null;
                     }
 
-                    paths = new String[files.size()];
-                    for (int i = 0; i < files.size(); i++) {
+                    final int size = files.size();
+                    paths = new String[size];
+                    for (int i = 0; i < size; i++) {
                         File f = files.get(i);
                         paths[i] = FileUtil.safeGetCanonicalPath(f);
 
@@ -644,13 +660,13 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
 
         @Override
-        protected void onCancelled(String[] result) {
+        protected void onCancelled(final String[] result) {
             disableScanning();
             super.onCancelled(result);
         }
 
         @Override
-        protected void onPostExecute(String[] paths) {
+        protected void onPostExecute(final String[] paths) {
             super.onPostExecute(paths);
             disableScanning();
             if (onPathsListedCallback != null && paths != null) {
@@ -659,7 +675,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
 
         private void disableScanning() {
-            Context context = getContext();
+            final Context context = getContext();
             if (context instanceof MainActivity) {
                 ((MainActivity) context).setScanning(false);
             }
@@ -676,9 +692,9 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
 
         public static class LoadingInfo {
             public final File file;
-            public final FileFilter fileFilter;
+            final FileFilter fileFilter;
 
-            public LoadingInfo(File file, FileFilter fileFilter) {
+            public LoadingInfo(final File file, final FileFilter fileFilter) {
                 this.file = file;
                 this.fileFilter = fileFilter;
             }
@@ -689,14 +705,14 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
     }
 
-    private static abstract class ListingFilesDialogAsyncTask<Params, Progress, Result> extends DialogAsyncTask<Params, Progress, Result> {
+    private abstract static class ListingFilesDialogAsyncTask<Params, Progress, Result> extends DialogAsyncTask<Params, Progress, Result> {
 
-        public ListingFilesDialogAsyncTask(Context context, int showDelay) {
+        ListingFilesDialogAsyncTask(final Context context, int showDelay) {
             super(context, showDelay);
         }
 
         @Override
-        protected Dialog createDialog(@NonNull Context context) {
+        protected Dialog createDialog(@NonNull final Context context) {
             return new MaterialDialog.Builder(context)
                     .title(R.string.listing_files)
                     .progress(true, 0)

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -223,11 +223,11 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     @NonNull
     @Override
     public AttachedCab openCab(int menuRes, final CabCallbacks callbacks) {
-        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
+        AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = ThemeStore.primaryColor(requireActivity());
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(getMainActivity(), layoutBinding.cabStubFolder.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(getMainActivity(), layoutBinding.cabHolder.getId(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -17,6 +17,7 @@ import android.webkit.MimeTypeMap;
 import android.widget.PopupMenu;
 import android.widget.Toast;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
@@ -26,7 +27,8 @@ import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.snackbar.Snackbar;
@@ -40,6 +42,7 @@ import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongsMenuHelper;
+import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.interfaces.LoaderIds;
 import com.poupa.vinylmusicplayer.misc.DialogAsyncTask;
@@ -80,7 +83,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     FastScrollRecyclerView recyclerView;
 
     private SongFileAdapter adapter;
-    private MaterialCab cab;
+    private AttachedCab cab;
 
     public FoldersFragment() {
     }
@@ -217,8 +220,8 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
 
     @Override
     public boolean handleBackPress() {
-        if (cab != null && cab.isActive()) {
-            cab.finish();
+        if (cab != null && AttachedCabKt.isActive(cab)) {
+            AttachedCabKt.destroy(cab);
             return true;
         }
         if (breadCrumbs.popHistory()) {
@@ -230,14 +233,12 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
 
     @NonNull
     @Override
-    public MaterialCab openCab(int menuRes, MaterialCab.Callback callback) {
-        if (cab != null && cab.isActive()) cab.finish();
-        adapter.setColor(ThemeStore.primaryColor(getActivity()));
-        cab = MenuHelper.setOverflowMenu(getMainActivity(), menuRes, ThemeStore.primaryColor(getMainActivity()))
-                .start(callback);
+    public AttachedCab openCab(int menuRes, final CabCallbacks callbacks) {
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
 
-        MenuHelper.decorateDestructiveItems(cab.getMenu(), this.getContext());
-
+        @ColorInt final int color = ThemeStore.primaryColor(requireActivity());
+        adapter.setColor(color);
+        cab = MenuHelper.createAndOpenCab(getMainActivity(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -37,7 +37,6 @@ import com.poupa.vinylmusicplayer.R;
 import com.poupa.vinylmusicplayer.adapter.SongFileAdapter;
 import com.poupa.vinylmusicplayer.databinding.FragmentFolderBinding;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
-import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongMenuHelper;
 import com.poupa.vinylmusicplayer.helper.menu.SongsMenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
@@ -227,7 +226,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
 
         @ColorInt final int color = ThemeStore.primaryColor(requireActivity());
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(getMainActivity(), menuRes, color, callbacks);
+        cab = CabHolder.openCabImpl(getMainActivity(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -227,7 +227,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
 
         @ColorInt final int color = ThemeStore.primaryColor(requireActivity());
         adapter.setColor(color);
-        cab = MenuHelper.createAndOpenCab(getMainActivity(), layoutBinding.cabHolder.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(getMainActivity(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -31,7 +31,6 @@ import com.poupa.vinylmusicplayer.databinding.FragmentLibraryBinding;
 import com.poupa.vinylmusicplayer.dialogs.CreatePlaylistDialog;
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
-import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
 import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.model.Album;
@@ -52,7 +51,14 @@ import com.poupa.vinylmusicplayer.ui.fragments.mainactivity.library.pager.SongsF
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.Util;
 
-public class LibraryFragment extends AbsMainActivityFragment implements CabHolder, MainActivity.MainActivityFragmentCallbacks, ViewPager.OnPageChangeListener, SharedPreferences.OnSharedPreferenceChangeListener {
+public class LibraryFragment
+        extends AbsMainActivityFragment
+        implements
+            CabHolder,
+            MainActivity.MainActivityFragmentCallbacks,
+            ViewPager.OnPageChangeListener,
+            SharedPreferences.OnSharedPreferenceChangeListener
+{
     private FragmentLibraryBinding layoutBinding;
 
     private MusicLibraryPagerAdapter pagerAdapter;
@@ -152,7 +158,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = ThemeStore.primaryColor(getMainActivity());
-        cab = MenuHelper.createAndOpenCab(getMainActivity(), menuRes, color, callbacks);
+        cab = CabHolder.openCabImpl(getMainActivity(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -12,13 +12,15 @@ import android.view.SubMenu;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager.widget.ViewPager;
 
-import com.afollestad.materialcab.MaterialCab;
+import com.afollestad.materialcab.attached.AttachedCab;
+import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.tabs.TabLayout;
 import com.kabouzeid.appthemehelper.ThemeStore;
@@ -32,6 +34,7 @@ import com.poupa.vinylmusicplayer.dialogs.CreatePlaylistDialog;
 import com.poupa.vinylmusicplayer.discog.Discography;
 import com.poupa.vinylmusicplayer.helper.MusicPlayerRemote;
 import com.poupa.vinylmusicplayer.helper.menu.MenuHelper;
+import com.poupa.vinylmusicplayer.interfaces.CabCallbacks;
 import com.poupa.vinylmusicplayer.interfaces.CabHolder;
 import com.poupa.vinylmusicplayer.model.Album;
 import com.poupa.vinylmusicplayer.model.Artist;
@@ -58,7 +61,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     ViewPager pager;
 
     private MusicLibraryPagerAdapter pagerAdapter;
-    private MaterialCab cab;
+    private AttachedCab cab;
 
     public static LibraryFragment newInstance() {
         return new LibraryFragment();
@@ -158,13 +161,11 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
 
     @NonNull
     @Override
-    public MaterialCab openCab(final int menuRes, final MaterialCab.Callback callback) {
-        if (cab != null && cab.isActive()) cab.finish();
-        cab = MenuHelper.setOverflowMenu(getMainActivity(), menuRes, ThemeStore.primaryColor(getMainActivity()))
-                .start(callback);
+    public AttachedCab openCab(final int menuRes, final CabCallbacks callbacks) {
+        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
 
-        MenuHelper.decorateDestructiveItems(cab.getMenu(), this.getContext());
-
+        @ColorInt final int color = ThemeStore.primaryColor(getMainActivity());
+        cab = MenuHelper.createAndOpenCab(getMainActivity(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -152,7 +152,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = ThemeStore.primaryColor(getMainActivity());
-        cab = MenuHelper.createAndOpenCab(getMainActivity(), layoutBinding.cabHolderLibrary.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(getMainActivity(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -55,10 +55,10 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.Util;
 
 public class LibraryFragment extends AbsMainActivityFragment implements CabHolder, MainActivity.MainActivityFragmentCallbacks, ViewPager.OnPageChangeListener, SharedPreferences.OnSharedPreferenceChangeListener {
-    Toolbar toolbar;
-    TabLayout tabs;
-    AppBarLayout appbar;
-    ViewPager pager;
+    private Toolbar toolbar;
+    private TabLayout tabs;
+    private AppBarLayout appbar;
+    private ViewPager pager;
 
     private MusicLibraryPagerAdapter pagerAdapter;
     private AttachedCab cab;
@@ -67,12 +67,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         return new LibraryFragment();
     }
 
-    public LibraryFragment() {
-    }
-
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        FragmentLibraryBinding binding = FragmentLibraryBinding.inflate(inflater, container, false);
+    public View onCreateView(@NonNull final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
+        final FragmentLibraryBinding binding = FragmentLibraryBinding.inflate(inflater, container, false);
         toolbar = binding.toolbar;
         tabs = binding.tabs;
         appbar = binding.appbar;
@@ -89,7 +86,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     }
 
     @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull final View view, @Nullable final Bundle savedInstanceState) {
         PreferenceUtil.getInstance().registerOnSharedPreferenceChangedListener(this);
         getMainActivity().setStatusbarColorAuto();
         getMainActivity().setNavigationbarColorAuto();
@@ -100,9 +97,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     }
 
     @Override
-    public void onSharedPreferenceChanged(SharedPreferences preferences, String key) {
+    public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String key) {
         if (PreferenceUtil.LIBRARY_CATEGORIES.equals(key)) {
-            Fragment current = getCurrentFragment();
+            final Fragment current = getCurrentFragment();
             pagerAdapter.setCategoryInfos(PreferenceUtil.getInstance().getLibraryCategoryInfos());
             pager.setOffscreenPageLimit(pagerAdapter.getCount() - 1);
             int position = pagerAdapter.getItemPosition(current);
@@ -116,27 +113,27 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     }
 
     private void setUpToolbar() {
-        int primaryColor = ThemeStore.primaryColor(getActivity());
+        final int primaryColor = ThemeStore.primaryColor(requireActivity());
         appbar.setBackgroundColor(primaryColor);
         toolbar.setBackgroundColor(primaryColor);
         toolbar.setNavigationIcon(R.drawable.ic_menu_white_24dp);
-        getActivity().setTitle(R.string.app_name);
+        requireActivity().setTitle(R.string.app_name);
         getMainActivity().setSupportActionBar(toolbar);
     }
 
     private void setUpViewPager() {
-        pagerAdapter = new MusicLibraryPagerAdapter(getActivity(), getChildFragmentManager());
+        pagerAdapter = new MusicLibraryPagerAdapter(requireActivity(), getChildFragmentManager());
         pager.setAdapter(pagerAdapter);
         pager.setOffscreenPageLimit(pagerAdapter.getCount() - 1);
 
         tabs.setupWithViewPager(pager);
 
-        int primaryColor = ThemeStore.primaryColor(getActivity());
-        int normalColor = ToolbarContentTintHelper.toolbarSubtitleColor(getActivity(), primaryColor);
-        int selectedColor = ToolbarContentTintHelper.toolbarTitleColor(getActivity(), primaryColor);
+        final int primaryColor = ThemeStore.primaryColor(requireActivity());
+        final int normalColor = ToolbarContentTintHelper.toolbarSubtitleColor(requireActivity(), primaryColor);
+        final int selectedColor = ToolbarContentTintHelper.toolbarTitleColor(requireActivity(), primaryColor);
         TabLayoutUtil.setTabIconColors(tabs, normalColor, selectedColor);
         tabs.setTabTextColors(normalColor, selectedColor);
-        tabs.setSelectedTabIndicatorColor(ThemeStore.accentColor(getActivity()));
+        tabs.setSelectedTabIndicatorColor(ThemeStore.accentColor(requireActivity()));
 
         updateTabVisibility();
 
@@ -151,7 +148,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         tabs.setVisibility(pagerAdapter.getCount() == 1 ? View.GONE : View.VISIBLE);
     }
 
-    public Fragment getCurrentFragment() {
+    private Fragment getCurrentFragment() {
         return pagerAdapter.getFragment(pager.getCurrentItem());
     }
 
@@ -169,12 +166,12 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         return cab;
     }
 
-    public void addOnAppBarOffsetChangedListener(AppBarLayout.OnOffsetChangedListener onOffsetChangedListener) {
-        appbar.addOnOffsetChangedListener(onOffsetChangedListener);
+    public void addOnAppBarOffsetChangedListener(final AppBarLayout.OnOffsetChangedListener listener) {
+        appbar.addOnOffsetChangedListener(listener);
     }
 
-    public void removeOnAppBarOffsetChangedListener(AppBarLayout.OnOffsetChangedListener onOffsetChangedListener) {
-        appbar.removeOnOffsetChangedListener(onOffsetChangedListener);
+    public void removeOnAppBarOffsetChangedListener(final AppBarLayout.OnOffsetChangedListener listener) {
+        appbar.removeOnOffsetChangedListener(listener);
     }
 
     public int getTotalAppBarScrollingRange() {
@@ -182,60 +179,60 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     }
 
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+    public void onCreateOptionsMenu(@NonNull final Menu menu, @NonNull final MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
-        if (pager == null) return;
+        if (pager == null) {return;}
         inflater.inflate(R.menu.menu_main, menu);
         if (isPlaylistPage()) {
             menu.add(0, R.id.action_new_playlist, 0, R.string.new_playlist_title);
         }
-        Fragment currentFragment = getCurrentFragment();
+        final Fragment currentFragment = getCurrentFragment();
         if (currentFragment instanceof AbsLibraryPagerRecyclerViewCustomGridSizeFragment && currentFragment.isAdded()) {
-            AbsLibraryPagerRecyclerViewCustomGridSizeFragment absLibraryRecyclerViewCustomGridSizeFragment = (AbsLibraryPagerRecyclerViewCustomGridSizeFragment) currentFragment;
+            final AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment = (AbsLibraryPagerRecyclerViewCustomGridSizeFragment) currentFragment;
 
-            MenuItem gridSizeItem = menu.findItem(R.id.action_grid_size);
+            final MenuItem gridSizeItem = menu.findItem(R.id.action_grid_size);
             if (Util.isLandscape(getResources())) {
                 gridSizeItem.setTitle(R.string.action_grid_size_land);
             }
-            setUpGridSizeMenu(absLibraryRecyclerViewCustomGridSizeFragment, gridSizeItem.getSubMenu());
+            setUpGridSizeMenu(fragment, gridSizeItem.getSubMenu());
 
-            menu.findItem(R.id.action_colored_footers).setChecked(absLibraryRecyclerViewCustomGridSizeFragment.usePalette());
-            menu.findItem(R.id.action_colored_footers).setEnabled(absLibraryRecyclerViewCustomGridSizeFragment.canUsePalette());
+            menu.findItem(R.id.action_colored_footers).setChecked(fragment.usePalette());
+            menu.findItem(R.id.action_colored_footers).setEnabled(fragment.canUsePalette());
 
-            setUpSortOrderMenu(absLibraryRecyclerViewCustomGridSizeFragment, menu.findItem(R.id.action_sort_order).getSubMenu());
+            setUpSortOrderMenu(fragment, menu.findItem(R.id.action_sort_order).getSubMenu());
         } else {
             menu.removeItem(R.id.action_grid_size);
             menu.removeItem(R.id.action_colored_footers);
             menu.removeItem(R.id.action_sort_order);
         }
-        Activity activity = getActivity();
-        if (activity == null) return;
-        ToolbarContentTintHelper.handleOnCreateOptionsMenu(getActivity(), toolbar, menu, ATHToolbarActivity.getToolbarBackgroundColor(toolbar));
+        final Activity activity = getActivity();
+        if (activity == null) {return;}
+        ToolbarContentTintHelper.handleOnCreateOptionsMenu(activity, toolbar, menu, ATHToolbarActivity.getToolbarBackgroundColor(toolbar));
     }
 
     @Override
-    public void onPrepareOptionsMenu(@NonNull Menu menu) {
+    public void onPrepareOptionsMenu(@NonNull final Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        Activity activity = getActivity();
-        if (activity == null) return;
+        final Activity activity = getActivity();
+        if (activity == null) {return;}
         ToolbarContentTintHelper.handleOnPrepareOptionsMenu(activity, toolbar);
     }
 
     @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        if (pager == null) return false;
-        Fragment currentFragment = getCurrentFragment();
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        if (pager == null) {return false;}
+        final Fragment currentFragment = getCurrentFragment();
         if (currentFragment instanceof AbsLibraryPagerRecyclerViewCustomGridSizeFragment) {
-            AbsLibraryPagerRecyclerViewCustomGridSizeFragment absLibraryRecyclerViewCustomGridSizeFragment = (AbsLibraryPagerRecyclerViewCustomGridSizeFragment) currentFragment;
+            final AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment = (AbsLibraryPagerRecyclerViewCustomGridSizeFragment) currentFragment;
             if (item.getItemId() == R.id.action_colored_footers) {
                 item.setChecked(!item.isChecked());
-                absLibraryRecyclerViewCustomGridSizeFragment.setAndSaveUsePalette(item.isChecked());
+                fragment.setAndSaveUsePalette(item.isChecked());
                 return true;
             }
-            if (handleGridSizeMenuItem(absLibraryRecyclerViewCustomGridSizeFragment, item)) {
+            if (handleGridSizeMenuItem(fragment, item)) {
                 return true;
             }
-            if (handleSortOrderMenuItem(absLibraryRecyclerViewCustomGridSizeFragment, item)) {
+            if (handleSortOrderMenuItem(fragment, item)) {
                 return true;
             }
         }
@@ -254,7 +251,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         return super.onOptionsItemSelected(item);
     }
 
-    private void setUpGridSizeMenu(@NonNull AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull SubMenu gridSizeMenu) {
+    private void setUpGridSizeMenu(@NonNull final AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull final SubMenu gridSizeMenu) {
         switch (fragment.getGridSize()) {
             case 1:
                 gridSizeMenu.findItem(R.id.action_grid_size_1).setChecked(true);
@@ -281,7 +278,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 gridSizeMenu.findItem(R.id.action_grid_size_8).setChecked(true);
                 break;
         }
-        int maxGridSize = fragment.getMaxGridSize();
+        final int maxGridSize = fragment.getMaxGridSize();
         if (maxGridSize < 8) {
             gridSizeMenu.findItem(R.id.action_grid_size_8).setVisible(false);
         }
@@ -302,7 +299,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         }
     }
 
-    private boolean handleGridSizeMenuItem(@NonNull AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull MenuItem item) {
+    private boolean handleGridSizeMenuItem(@NonNull final AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull final MenuItem item) {
         int gridSize = 0;
         final int itemId = item.getItemId();
         if (itemId == R.id.action_grid_size_1) {
@@ -331,8 +328,8 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         return false;
     }
 
-    private void setUpSortOrderMenu(@NonNull AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull SubMenu sortOrderMenu) {
-        String currentSortOrder = fragment.getSortOrder();
+    private void setUpSortOrderMenu(@NonNull final AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull final SubMenu sortOrderMenu) {
+        final String currentSortOrder = fragment.getSortOrder();
         sortOrderMenu.clear();
 
         if (fragment instanceof AlbumsFragment) {
@@ -346,17 +343,17 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         sortOrderMenu.setGroupCheckable(0, true, true);
     }
 
-    private boolean handleSortOrderMenuItem(@NonNull AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull MenuItem item) {
+    private boolean handleSortOrderMenuItem(@NonNull final AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull final MenuItem item) {
         String sortOrder = null;
         final int itemId = item.getItemId();
         if (fragment instanceof AlbumsFragment) {
-            SortOrder<Album> sorter = AlbumSortOrder.fromMenuResourceId(itemId);
+            final SortOrder<Album> sorter = AlbumSortOrder.fromMenuResourceId(itemId);
             if (sorter != null) {sortOrder = sorter.preferenceValue;}
         } else if (fragment instanceof ArtistsFragment) {
-            SortOrder<Artist> sorter = ArtistSortOrder.fromMenuResourceId(itemId);
+            final SortOrder<Artist> sorter = ArtistSortOrder.fromMenuResourceId(itemId);
             if (sorter != null) {sortOrder = sorter.preferenceValue;}
         } else if (fragment instanceof SongsFragment) {
-            SortOrder<Song> sorter = SongSortOrder.fromMenuResourceId(itemId);
+            final SortOrder<Song> sorter = SongSortOrder.fromMenuResourceId(itemId);
             if (sorter != null) {sortOrder = sorter.preferenceValue;}
         }
 
@@ -371,8 +368,8 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
 
     @Override
     public boolean handleBackPress() {
-        if (cab != null && cab.isActive()) {
-            cab.finish();
+        if (cab != null && AttachedCabKt.isActive(cab)) {
+            AttachedCabKt.destroy(cab);
             return true;
         }
         return false;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -149,10 +149,10 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     @NonNull
     @Override
     public AttachedCab openCab(final int menuRes, final CabCallbacks callbacks) {
-        if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
+        AttachedCabKt.destroy(cab);
 
         @ColorInt final int color = ThemeStore.primaryColor(getMainActivity());
-        cab = MenuHelper.createAndOpenCab(getMainActivity(), layoutBinding.cabStubLibrary.getId(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(getMainActivity(), layoutBinding.cabHolderLibrary.getId(), menuRes, color, callbacks);
         return cab;
     }
 

--- a/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -15,14 +15,12 @@ import android.view.ViewGroup;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager.widget.ViewPager;
 
 import com.afollestad.materialcab.attached.AttachedCab;
 import com.afollestad.materialcab.attached.AttachedCabKt;
 import com.google.android.material.appbar.AppBarLayout;
-import com.google.android.material.tabs.TabLayout;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.kabouzeid.appthemehelper.common.ATHToolbarActivity;
 import com.kabouzeid.appthemehelper.util.TabLayoutUtil;
@@ -55,10 +53,7 @@ import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 import com.poupa.vinylmusicplayer.util.Util;
 
 public class LibraryFragment extends AbsMainActivityFragment implements CabHolder, MainActivity.MainActivityFragmentCallbacks, ViewPager.OnPageChangeListener, SharedPreferences.OnSharedPreferenceChangeListener {
-    private Toolbar toolbar;
-    private TabLayout tabs;
-    private AppBarLayout appbar;
-    private ViewPager pager;
+    private FragmentLibraryBinding layoutBinding;
 
     private MusicLibraryPagerAdapter pagerAdapter;
     private AttachedCab cab;
@@ -69,20 +64,15 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
 
     @Override
     public View onCreateView(@NonNull final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
-        final FragmentLibraryBinding binding = FragmentLibraryBinding.inflate(inflater, container, false);
-        toolbar = binding.toolbar;
-        tabs = binding.tabs;
-        appbar = binding.appbar;
-        pager = binding.pager;
-
-        return binding.getRoot();
+        layoutBinding = FragmentLibraryBinding.inflate(inflater, container, false);
+        return layoutBinding.getRoot();
     }
 
     @Override
     public void onDestroyView() {
         PreferenceUtil.getInstance().unregisterOnSharedPreferenceChangedListener(this);
         super.onDestroyView();
-        pager.removeOnPageChangeListener(this);
+        layoutBinding.pager.removeOnPageChangeListener(this);
     }
 
     @Override
@@ -101,55 +91,55 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         if (PreferenceUtil.LIBRARY_CATEGORIES.equals(key)) {
             final Fragment current = getCurrentFragment();
             pagerAdapter.setCategoryInfos(PreferenceUtil.getInstance().getLibraryCategoryInfos());
-            pager.setOffscreenPageLimit(pagerAdapter.getCount() - 1);
+            layoutBinding.pager.setOffscreenPageLimit(pagerAdapter.getCount() - 1);
             int position = pagerAdapter.getItemPosition(current);
             if (position < 0) position = 0;
-            pager.setCurrentItem(position);
+            layoutBinding.pager.setCurrentItem(position);
             PreferenceUtil.getInstance().setLastPage(position);
 
             // hide the tab bar with single tab
-            tabs.setVisibility(pagerAdapter.getCount() == 1 ? View.GONE : View.VISIBLE);
+            layoutBinding.tabs.setVisibility(pagerAdapter.getCount() == 1 ? View.GONE : View.VISIBLE);
         }
     }
 
     private void setUpToolbar() {
         final int primaryColor = ThemeStore.primaryColor(requireActivity());
-        appbar.setBackgroundColor(primaryColor);
-        toolbar.setBackgroundColor(primaryColor);
-        toolbar.setNavigationIcon(R.drawable.ic_menu_white_24dp);
+        layoutBinding.appbar.setBackgroundColor(primaryColor);
+        layoutBinding.toolbar.setBackgroundColor(primaryColor);
+        layoutBinding.toolbar.setNavigationIcon(R.drawable.ic_menu_white_24dp);
         requireActivity().setTitle(R.string.app_name);
-        getMainActivity().setSupportActionBar(toolbar);
+        getMainActivity().setSupportActionBar(layoutBinding.toolbar);
     }
 
     private void setUpViewPager() {
         pagerAdapter = new MusicLibraryPagerAdapter(requireActivity(), getChildFragmentManager());
-        pager.setAdapter(pagerAdapter);
-        pager.setOffscreenPageLimit(pagerAdapter.getCount() - 1);
+        layoutBinding.pager.setAdapter(pagerAdapter);
+        layoutBinding.pager.setOffscreenPageLimit(pagerAdapter.getCount() - 1);
 
-        tabs.setupWithViewPager(pager);
+        layoutBinding.tabs.setupWithViewPager(layoutBinding.pager);
 
         final int primaryColor = ThemeStore.primaryColor(requireActivity());
         final int normalColor = ToolbarContentTintHelper.toolbarSubtitleColor(requireActivity(), primaryColor);
         final int selectedColor = ToolbarContentTintHelper.toolbarTitleColor(requireActivity(), primaryColor);
-        TabLayoutUtil.setTabIconColors(tabs, normalColor, selectedColor);
-        tabs.setTabTextColors(normalColor, selectedColor);
-        tabs.setSelectedTabIndicatorColor(ThemeStore.accentColor(requireActivity()));
+        TabLayoutUtil.setTabIconColors(layoutBinding.tabs, normalColor, selectedColor);
+        layoutBinding.tabs.setTabTextColors(normalColor, selectedColor);
+        layoutBinding.tabs.setSelectedTabIndicatorColor(ThemeStore.accentColor(requireActivity()));
 
         updateTabVisibility();
 
         if (PreferenceUtil.getInstance().rememberLastTab()) {
-            pager.setCurrentItem(PreferenceUtil.getInstance().getLastPage());
+            layoutBinding.pager.setCurrentItem(PreferenceUtil.getInstance().getLastPage());
         }
-        pager.addOnPageChangeListener(this);
+        layoutBinding.pager.addOnPageChangeListener(this);
     }
 
     private void updateTabVisibility() {
         // hide the tab bar when only a single tab is visible
-        tabs.setVisibility(pagerAdapter.getCount() == 1 ? View.GONE : View.VISIBLE);
+        layoutBinding.tabs.setVisibility(pagerAdapter.getCount() == 1 ? View.GONE : View.VISIBLE);
     }
 
     private Fragment getCurrentFragment() {
-        return pagerAdapter.getFragment(pager.getCurrentItem());
+        return pagerAdapter.getFragment(layoutBinding.pager.getCurrentItem());
     }
 
     private boolean isPlaylistPage() {
@@ -162,26 +152,25 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         if (cab != null && AttachedCabKt.isActive(cab)) {AttachedCabKt.destroy(cab);}
 
         @ColorInt final int color = ThemeStore.primaryColor(getMainActivity());
-        cab = MenuHelper.createAndOpenCab(getMainActivity(), menuRes, color, callbacks);
+        cab = MenuHelper.createAndOpenCab(getMainActivity(), layoutBinding.cabStubLibrary.getId(), menuRes, color, callbacks);
         return cab;
     }
 
     public void addOnAppBarOffsetChangedListener(final AppBarLayout.OnOffsetChangedListener listener) {
-        appbar.addOnOffsetChangedListener(listener);
+        layoutBinding.appbar.addOnOffsetChangedListener(listener);
     }
 
     public void removeOnAppBarOffsetChangedListener(final AppBarLayout.OnOffsetChangedListener listener) {
-        appbar.removeOnOffsetChangedListener(listener);
+        layoutBinding.appbar.removeOnOffsetChangedListener(listener);
     }
 
     public int getTotalAppBarScrollingRange() {
-        return appbar.getTotalScrollRange();
+        return layoutBinding.appbar.getTotalScrollRange();
     }
 
     @Override
     public void onCreateOptionsMenu(@NonNull final Menu menu, @NonNull final MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
-        if (pager == null) {return;}
         inflater.inflate(R.menu.menu_main, menu);
         if (isPlaylistPage()) {
             menu.add(0, R.id.action_new_playlist, 0, R.string.new_playlist_title);
@@ -205,9 +194,11 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
             menu.removeItem(R.id.action_colored_footers);
             menu.removeItem(R.id.action_sort_order);
         }
-        final Activity activity = getActivity();
-        if (activity == null) {return;}
-        ToolbarContentTintHelper.handleOnCreateOptionsMenu(activity, toolbar, menu, ATHToolbarActivity.getToolbarBackgroundColor(toolbar));
+        ToolbarContentTintHelper.handleOnCreateOptionsMenu(
+                requireActivity(),
+                layoutBinding.toolbar,
+                menu,
+                ATHToolbarActivity.getToolbarBackgroundColor(layoutBinding.toolbar));
     }
 
     @Override
@@ -215,12 +206,11 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         super.onPrepareOptionsMenu(menu);
         final Activity activity = getActivity();
         if (activity == null) {return;}
-        ToolbarContentTintHelper.handleOnPrepareOptionsMenu(activity, toolbar);
+        ToolbarContentTintHelper.handleOnPrepareOptionsMenu(activity, layoutBinding.toolbar);
     }
 
     @Override
     public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
-        if (pager == null) {return false;}
         final Fragment currentFragment = getCurrentFragment();
         if (currentFragment instanceof AbsLibraryPagerRecyclerViewCustomGridSizeFragment) {
             final AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment = (AbsLibraryPagerRecyclerViewCustomGridSizeFragment) currentFragment;
@@ -322,7 +312,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         if (gridSize > 0) {
             item.setChecked(true);
             fragment.setAndSaveGridSize(gridSize);
-            toolbar.getMenu().findItem(R.id.action_colored_footers).setEnabled(fragment.canUsePalette());
+            layoutBinding.toolbar.getMenu().findItem(R.id.action_colored_footers).setEnabled(fragment.canUsePalette());
             return true;
         }
         return false;

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/ImageTheme/ThemeStyleUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/ImageTheme/ThemeStyleUtil.java
@@ -1,14 +1,16 @@
 package com.poupa.vinylmusicplayer.util.ImageTheme;
 
 
+import androidx.annotation.NonNull;
+
 import com.poupa.vinylmusicplayer.util.PreferenceUtil;
 
 public class ThemeStyleUtil {
     private static ThemeStyle sInstance;
 
-    public static ThemeStyle updateInstance(int themeState) {
+    public static ThemeStyle updateInstance(@NonNull final String themeName) {
         synchronized (ThemeStyleUtil.class) {
-            if (themeState == PreferenceUtil.ROUNDED_THEME) {
+            if (themeName.equals(PreferenceUtil.ROUNDED_THEME)) {
                 sInstance = new MaterialTheme();
             } else {
                 sInstance = new FlatTheme();

--- a/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
+++ b/app/src/main/java/com/poupa/vinylmusicplayer/util/PreferenceUtil.java
@@ -21,53 +21,56 @@ import com.poupa.vinylmusicplayer.model.CategoryInfo;
 import com.poupa.vinylmusicplayer.ui.fragments.mainactivity.folders.FoldersFragment;
 import com.poupa.vinylmusicplayer.ui.fragments.player.NowPlayingScreen;
 
+import org.jetbrains.annotations.NonNls;
+
 import java.io.File;
 import java.lang.reflect.Type;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class PreferenceUtil {
     // TODO Use string resources for this, avoid duplicating inside UI code
     public static final String GENERAL_THEME = "general_theme";
-    public static final String GENERAL_THEME_LIGHT = "light";
-    public static final String GENERAL_THEME_DARK = "dark";
-    public static final String GENERAL_THEME_BLACK = "black";
+    private static final String GENERAL_THEME_LIGHT = "light";
+    private static final String GENERAL_THEME_DARK = "dark";
+    private static final String GENERAL_THEME_BLACK = "black";
     public static final String GENERAL_THEME_FOLLOW_SYSTEM_LIGHT_OR_DARK = "follow_system_light_or_dark";
     public static final String GENERAL_THEME_FOLLOW_SYSTEM_LIGHT_OR_BLACK = "follow_system_light_or_black";
 
-    public static final String REMEMBER_LAST_TAB = "remember_last_tab";
-    public static final String LAST_PAGE = "last_start_page";
-    public static final String LAST_MUSIC_CHOOSER = "last_music_chooser";
+    private static final String REMEMBER_LAST_TAB = "remember_last_tab";
+    private static final String LAST_PAGE = "last_start_page";
+    private static final String LAST_MUSIC_CHOOSER = "last_music_chooser";
     public static final String NOW_PLAYING_SCREEN_ID = "now_playing_screen_id";
 
-    public static final String ARTIST_SORT_ORDER = "artist_sort_order";
-    public static final String ALBUM_SORT_ORDER = "album_sort_order";
-    public static final String SONG_SORT_ORDER = "song_sort_order";
+    private static final String ARTIST_SORT_ORDER = "artist_sort_order";
+    private static final String ALBUM_SORT_ORDER = "album_sort_order";
+    private static final String SONG_SORT_ORDER = "song_sort_order";
 
-    public static final String ALBUM_GRID_SIZE = "album_grid_size";
-    public static final String ALBUM_GRID_SIZE_LAND = "album_grid_size_land";
+    private static final String ALBUM_GRID_SIZE = "album_grid_size";
+    private static final String ALBUM_GRID_SIZE_LAND = "album_grid_size_land";
 
-    public static final String SONG_GRID_SIZE = "song_grid_size";
-    public static final String SONG_GRID_SIZE_LAND = "song_grid_size_land";
+    private static final String SONG_GRID_SIZE = "song_grid_size";
+    private static final String SONG_GRID_SIZE_LAND = "song_grid_size_land";
 
-    public static final String ARTIST_GRID_SIZE = "artist_grid_size";
-    public static final String ARTIST_GRID_SIZE_LAND = "artist_grid_size_land";
+    private static final String ARTIST_GRID_SIZE = "artist_grid_size";
+    private static final String ARTIST_GRID_SIZE_LAND = "artist_grid_size_land";
 
-    public static final String ALBUM_COLORED_FOOTERS = "album_colored_footers";
-    public static final String SONG_COLORED_FOOTERS = "song_colored_footers";
-    public static final String ARTIST_COLORED_FOOTERS = "artist_colored_footers";
-    public static final String ALBUM_ARTIST_COLORED_FOOTERS = "album_artist_colored_footers";
+    private static final String ALBUM_COLORED_FOOTERS = "album_colored_footers";
+    private static final String SONG_COLORED_FOOTERS = "song_colored_footers";
+    private static final String ARTIST_COLORED_FOOTERS = "artist_colored_footers";
+    private static final String ALBUM_ARTIST_COLORED_FOOTERS = "album_artist_colored_footers";
 
     public static final String COLORED_NOTIFICATION = "colored_notification";
     public static final String CLASSIC_NOTIFICATION = "classic_notification";
 
-    public static final String COLORED_APP_SHORTCUTS = "colored_app_shortcuts";
+    private static final String COLORED_APP_SHORTCUTS = "colored_app_shortcuts";
 
     public static final String TRANSPARENT_BACKGROUND_WIDGET = "make_widget_background_transparent";
 
-    public static final String AUDIO_DUCKING = "audio_ducking";
+    private static final String AUDIO_DUCKING = "audio_ducking";
     public static final String GAPLESS_PLAYBACK = "gapless_playback";
 
     @Deprecated public static final String LAST_ADDED_CUTOFF = "last_added_interval";
@@ -76,31 +79,35 @@ public final class PreferenceUtil {
     public static final String RECENTLY_PLAYED_CUTOFF_V2 = "recently_played_interval_v2";
     public static final String NOT_RECENTLY_PLAYED_CUTOFF_V2 = "not_recently_played_interval_v2";
     public static final String MAINTAIN_TOP_TRACKS_PLAYLIST = "maintain_top_tracks_playlist";
-    public static final String MAINTAIN_SKIPPED_SONGS_PLAYLIST = "maintain_skipped_songs_playlist";
+    private static final String MAINTAIN_SKIPPED_SONGS_PLAYLIST = "maintain_skipped_songs_playlist";
 
     public static final String ALBUM_ART_ON_LOCKSCREEN = "album_art_on_lockscreen";
     public static final String BLURRED_ALBUM_ART = "blurred_album_art";
 
-    public static final String LAST_SLEEP_TIMER_VALUE = "last_sleep_timer_value";
-    public static final String NEXT_SLEEP_TIMER_ELAPSED_REALTIME = "next_sleep_timer_elapsed_real_time";
-    public static final String SLEEP_TIMER_FINISH_SONG = "sleep_timer_finish_music";
+    private static final String LAST_SLEEP_TIMER_VALUE = "last_sleep_timer_value";
+    private static final String NEXT_SLEEP_TIMER_ELAPSED_REALTIME = "next_sleep_timer_elapsed_real_time";
+    private static final String SLEEP_TIMER_FINISH_SONG = "sleep_timer_finish_music";
 
-    public static final String IGNORE_MEDIA_STORE_ARTWORK = "ignore_media_store_artwork";
+    private static final String IGNORE_MEDIA_STORE_ARTWORK = "ignore_media_store_artwork";
 
-    public static final String LAST_CHANGELOG_VERSION = "last_changelog_version";
-    public static final String INTRO_SHOWN = "intro_shown";
+    private static final String LAST_CHANGELOG_VERSION = "last_changelog_version";
+    private static final String INTRO_SHOWN = "intro_shown";
 
     public static final String AUTO_DOWNLOAD_IMAGES_POLICY = "auto_download_images_policy";
+    private static final String AUTO_DOWNLOAD_ALWAYS = "always";
+    private static final String AUTO_DOWNLOAD_WIFI_ONLY = "only_wifi";
+    private static final String AUTO_DOWNLOAD_NEVER = "never";
 
-    public static final String START_DIRECTORY = "start_directory";
+    private static final String START_DIRECTORY = "start_directory";
 
-    public static final String SYNCHRONIZED_LYRICS_SHOW = "synchronized_lyrics_show";
-    public static final String ANIMATE_PLAYING_SONG_ICON = "animate_playing_song_icon";
-    public static final String SHOW_SONG_NUMBER = "show_song_number_on_playing_queue";
+    private static final String SYNCHRONIZED_LYRICS_SHOW = "synchronized_lyrics_show";
+    private static final String ANIMATE_PLAYING_SONG_ICON = "animate_playing_song_icon";
+    private static final String SHOW_SONG_NUMBER = "show_song_number_on_playing_queue";
 
-    public static final String INITIALIZED_BLACKLIST = "initialized_blacklist";
+    private static final String INITIALIZED_BLACKLIST = "initialized_blacklist";
     public static final String WHITELIST_ENABLED = "whitelist_enabled";
 
+    @NonNls
     public static final String LIBRARY_CATEGORIES = "library_categories";
 
     private static final String REMEMBER_SHUFFLE = "remember_shuffle";
@@ -111,14 +118,16 @@ public final class PreferenceUtil {
     public static final String RG_PREAMP_WITHOUT_TAG = "replaygain_preamp_without_tag";
 
     public static final String THEME_STYLE = "theme_style";
-    public static final int CLASSIC_THEME = 1;
-    public static final int ROUNDED_THEME = 2;
+    @NonNls
+    private static final String CLASSIC_THEME = "classic";
+    @NonNls
+    public static final String ROUNDED_THEME = "rounded";
 
     public static final byte RG_SOURCE_MODE_NONE = 0;
     public static final byte RG_SOURCE_MODE_TRACK = 1;
     public static final byte RG_SOURCE_MODE_ALBUM = 2;
 
-    public static final String SAF_SDCARD_URI = "saf_sdcard_uri";
+    private static final String SAF_SDCARD_URI = "saf_sdcard_uri";
 
     private static PreferenceUtil sInstance;
 
@@ -150,23 +159,23 @@ public final class PreferenceUtil {
 
     public static boolean isAllowedToDownloadMetadata(final Context context) {
         switch (getInstance().autoDownloadImagesPolicy()) {
-            case "always":
+            case AUTO_DOWNLOAD_ALWAYS:
                 return true;
-            case "only_wifi":
+            case AUTO_DOWNLOAD_WIFI_ONLY:
                 final ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
                 NetworkInfo netInfo = connectivityManager.getActiveNetworkInfo();
                 return netInfo != null && netInfo.getType() == ConnectivityManager.TYPE_WIFI && netInfo.isConnectedOrConnecting();
-            case "never":
+            case AUTO_DOWNLOAD_NEVER:
             default:
                 return false;
         }
     }
 
-    public void registerOnSharedPreferenceChangedListener(SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener) {
+    public void registerOnSharedPreferenceChangedListener(final SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener) {
         mPreferences.registerOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
     }
 
-    public void unregisterOnSharedPreferenceChangedListener(SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener) {
+    public void unregisterOnSharedPreferenceChangedListener(final SharedPreferences.OnSharedPreferenceChangeListener sharedPreferenceChangeListener) {
         mPreferences.unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener);
     }
 
@@ -176,7 +185,7 @@ public final class PreferenceUtil {
     }
 
     @StyleRes
-    public static int getThemeResFromPrefValue(String themePrefValue) {
+    public static int getThemeResFromPrefValue(@NonNull final String themePrefValue) {
         final boolean isNightMode = (VinylMusicPlayerColorUtil.getSystemNightMode(App.getStaticContext()) == Configuration.UI_MODE_NIGHT_YES);
 
         switch (themePrefValue) {
@@ -194,7 +203,7 @@ public final class PreferenceUtil {
         }
     }
 
-    public final boolean rememberLastTab() {
+    public boolean rememberLastTab() {
         return mPreferences.getBoolean(REMEMBER_LAST_TAB, true);
     }
 
@@ -204,7 +213,7 @@ public final class PreferenceUtil {
         editor.apply();
     }
 
-    public final int getLastPage() {
+    public int getLastPage() {
         return mPreferences.getInt(LAST_PAGE, 0);
     }
 
@@ -214,14 +223,14 @@ public final class PreferenceUtil {
         editor.apply();
     }
 
-    public final int getLastMusicChooser() {
+    public int getLastMusicChooser() {
         return mPreferences.getInt(LAST_MUSIC_CHOOSER, 0);
     }
 
-    public final NowPlayingScreen getNowPlayingScreen() {
-        int id = mPreferences.getInt(NOW_PLAYING_SCREEN_ID, 0);
-        for (NowPlayingScreen nowPlayingScreen : NowPlayingScreen.values()) {
-            if (nowPlayingScreen.id == id) return nowPlayingScreen;
+    public NowPlayingScreen getNowPlayingScreen() {
+        final int id = mPreferences.getInt(NOW_PLAYING_SCREEN_ID, 0);
+        for (final NowPlayingScreen nowPlayingScreen : NowPlayingScreen.values()) {
+            if (nowPlayingScreen.id == id) {return nowPlayingScreen;}
         }
         return NowPlayingScreen.CARD;
     }
@@ -232,11 +241,11 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean coloredNotification() {
+    public boolean coloredNotification() {
         return mPreferences.getBoolean(COLORED_NOTIFICATION, true);
     }
 
-    public final boolean classicNotification() {
+    public boolean classicNotification() {
         return mPreferences.getBoolean(CLASSIC_NOTIFICATION, false);
     }
 
@@ -258,7 +267,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean coloredAppShortcuts() {
+    public boolean coloredAppShortcuts() {
         return mPreferences.getBoolean(COLORED_APP_SHORTCUTS, true);
     }
 
@@ -268,31 +277,31 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean transparentBackgroundWidget() {
+    public boolean transparentBackgroundWidget() {
         return mPreferences.getBoolean(TRANSPARENT_BACKGROUND_WIDGET, false);
     }
 
-    public final boolean gaplessPlayback() {
+    public boolean gaplessPlayback() {
         return mPreferences.getBoolean(GAPLESS_PLAYBACK, false);
     }
 
-    public final boolean audioDucking() {
+    public boolean audioDucking() {
         return mPreferences.getBoolean(AUDIO_DUCKING, true);
     }
 
-    public final boolean albumArtOnLockscreen() {
+    public boolean albumArtOnLockscreen() {
         return mPreferences.getBoolean(ALBUM_ART_ON_LOCKSCREEN, true);
     }
 
-    public final boolean blurredAlbumArt() {
+    public boolean blurredAlbumArt() {
         return mPreferences.getBoolean(BLURRED_ALBUM_ART, false);
     }
 
-    public final boolean ignoreMediaStoreArtwork() {
+    public boolean ignoreMediaStoreArtwork() {
         return mPreferences.getBoolean(IGNORE_MEDIA_STORE_ARTWORK, false);
     }
 
-    public final String getArtistSortOrder() {
+    public String getArtistSortOrder() {
         return mPreferences.getString(ARTIST_SORT_ORDER, "");
     }
 
@@ -302,7 +311,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final String getAlbumSortOrder() {
+    public String getAlbumSortOrder() {
         return mPreferences.getString(ALBUM_SORT_ORDER, "");
     }
 
@@ -312,7 +321,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final String getSongSortOrder() {
+    public String getSongSortOrder() {
         return mPreferences.getString(SONG_SORT_ORDER, "");
     }
 
@@ -325,7 +334,7 @@ public final class PreferenceUtil {
     private void migrateCutoffV1AsV2(@NonNull final String cutoffV1, @NonNull final String cutoffV2) {
         if (mPreferences.contains(cutoffV2)) {return;}
 
-        String migratedValue;
+        final String migratedValue;
         switch (mPreferences.getString(cutoffV1, "")) {
             case "today":
                 migratedValue = "1d";
@@ -376,7 +385,7 @@ public final class PreferenceUtil {
         final Pattern pattern = Pattern.compile("^([0-9]*?)([dwmy])$");
         final Matcher matcher = pattern.matcher(value);
         if (matcher.find()) {
-            final int count = Integer.parseInt(matcher.group(1));
+            final int count = Integer.parseInt(Objects.requireNonNull(matcher.group(1)));
             final String unit = matcher.group(2);
 
             if (count == 0) {return disabledValue;}
@@ -416,7 +425,7 @@ public final class PreferenceUtil {
     }
 
     @NonNull
-    private String getCutoffTextV2(@NonNull final String cutoff, Context context) {
+    private String getCutoffTextV2(@NonNull final String cutoff, final Context context) {
         final Pair<Integer, ChronoUnit> value = getCutoffTimeV2(cutoff);
         if (value.first <= 0) {return context.getString(R.string.pref_playlist_disabled);}
 
@@ -442,17 +451,17 @@ public final class PreferenceUtil {
     }
 
     @NonNull
-    public String getLastAddedCutoffText(@NonNull Context context) {
+    public String getLastAddedCutoffText(@NonNull final Context context) {
         return getCutoffTextV2(LAST_ADDED_CUTOFF_V2, context);
     }
 
     @NonNull
-    public String getRecentlyPlayedCutoffText(Context context) {
+    public String getRecentlyPlayedCutoffText(final Context context) {
         return getCutoffTextV2(RECENTLY_PLAYED_CUTOFF_V2, context);
     }
 
     @NonNull
-    public String getNotRecentlyPlayedCutoffText(Context context) {
+    public String getNotRecentlyPlayedCutoffText(final Context context) {
         return getCutoffTextV2(NOT_RECENTLY_PLAYED_CUTOFF_V2, context);
     }
 
@@ -492,7 +501,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final int getAlbumGridSize(Context context) {
+    public int getAlbumGridSize(@NonNull final Context context) {
         return mPreferences.getInt(ALBUM_GRID_SIZE, context.getResources().getInteger(R.integer.default_grid_columns));
     }
 
@@ -502,7 +511,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final int getSongGridSize(Context context) {
+    public int getSongGridSize(@NonNull final Context context) {
         return mPreferences.getInt(SONG_GRID_SIZE, context.getResources().getInteger(R.integer.default_list_columns));
     }
 
@@ -512,7 +521,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final int getArtistGridSize(Context context) {
+    public int getArtistGridSize(@NonNull final Context context) {
         return mPreferences.getInt(ARTIST_GRID_SIZE, context.getResources().getInteger(R.integer.default_list_columns));
     }
 
@@ -522,7 +531,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final int getAlbumGridSizeLand(Context context) {
+    public int getAlbumGridSizeLand(@NonNull final Context context) {
         return mPreferences.getInt(ALBUM_GRID_SIZE_LAND, context.getResources().getInteger(R.integer.default_grid_columns_land));
     }
 
@@ -532,7 +541,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final int getSongGridSizeLand(Context context) {
+    public int getSongGridSizeLand(@NonNull final Context context) {
         return mPreferences.getInt(SONG_GRID_SIZE_LAND, context.getResources().getInteger(R.integer.default_list_columns_land));
     }
 
@@ -542,7 +551,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final int getArtistGridSizeLand(Context context) {
+    public int getArtistGridSizeLand(@NonNull final Context context) {
         return mPreferences.getInt(ARTIST_GRID_SIZE_LAND, context.getResources().getInteger(R.integer.default_list_columns_land));
     }
 
@@ -552,7 +561,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean albumColoredFooters() {
+    public boolean albumColoredFooters() {
         return mPreferences.getBoolean(ALBUM_COLORED_FOOTERS, true);
     }
 
@@ -562,7 +571,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean albumArtistColoredFooters() {
+    public boolean albumArtistColoredFooters() {
         return mPreferences.getBoolean(ALBUM_ARTIST_COLORED_FOOTERS, true);
     }
 
@@ -572,7 +581,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean songColoredFooters() {
+    public boolean songColoredFooters() {
         return mPreferences.getBoolean(SONG_COLORED_FOOTERS, true);
     }
 
@@ -582,7 +591,7 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean artistColoredFooters() {
+    public boolean artistColoredFooters() {
         return mPreferences.getBoolean(ARTIST_COLORED_FOOTERS, true);
     }
 
@@ -590,7 +599,7 @@ public final class PreferenceUtil {
         mPreferences.edit().putInt(LAST_CHANGELOG_VERSION, version).apply();
     }
 
-    public final int getLastChangelogVersion() {
+    public int getLastChangelogVersion() {
         return mPreferences.getInt(LAST_CHANGELOG_VERSION, -1);
     }
 
@@ -598,37 +607,37 @@ public final class PreferenceUtil {
         mPreferences.edit().putBoolean(INTRO_SHOWN, true).apply();
     }
 
-    public final boolean introShown() {
+    public boolean introShown() {
         return mPreferences.getBoolean(INTRO_SHOWN, false);
     }
 
-    public final boolean rememberShuffle() {
+    public boolean rememberShuffle() {
         return mPreferences.getBoolean(REMEMBER_SHUFFLE, true);
     }
 
-    public final String autoDownloadImagesPolicy() {
-        return mPreferences.getString(AUTO_DOWNLOAD_IMAGES_POLICY, "only_wifi");
+    private String autoDownloadImagesPolicy() {
+        return mPreferences.getString(AUTO_DOWNLOAD_IMAGES_POLICY, AUTO_DOWNLOAD_WIFI_ONLY);
     }
 
-    public final File getStartDirectory() {
+    public File getStartDirectory() {
         return new File(mPreferences.getString(START_DIRECTORY, FoldersFragment.getDefaultStartDirectory().getPath()));
     }
 
-    public void setStartDirectory(File file) {
+    public void setStartDirectory(final File file) {
         mPreferences.edit()
                 .putString(START_DIRECTORY, FileUtil.safeGetCanonicalPath(file))
                 .apply();
     }
 
-    public final boolean synchronizedLyricsShow() {
+    public boolean synchronizedLyricsShow() {
         return mPreferences.getBoolean(SYNCHRONIZED_LYRICS_SHOW, true);
     }
 
-    public final boolean animatePlayingSongIcon() {
+    public boolean animatePlayingSongIcon() {
         return mPreferences.getBoolean(ANIMATE_PLAYING_SONG_ICON, false);
     }
 
-    public final boolean showSongNumber() {
+    boolean showSongNumber() {
         return mPreferences.getBoolean(SHOW_SONG_NUMBER, false);
     }
 
@@ -646,17 +655,17 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final boolean initializedBlacklist() {
+    public boolean initializedBlacklist() {
         return mPreferences.getBoolean(INITIALIZED_BLACKLIST, false);
     }
 
-    public final boolean getWhitelistEnabled() {
+    public boolean getWhitelistEnabled() {
         return mPreferences.getBoolean(WHITELIST_ENABLED, false);
     }
 
-    public void setLibraryCategoryInfos(ArrayList<CategoryInfo> categories) {
-        Gson gson = new Gson();
-        Type collectionType = new TypeToken<ArrayList<CategoryInfo>>() {
+    public void setLibraryCategoryInfos(final ArrayList<CategoryInfo> categories) {
+        final Gson gson = new Gson();
+        final Type collectionType = new TypeToken<ArrayList<CategoryInfo>>() {
         }.getType();
 
         mPreferences.edit()
@@ -667,13 +676,13 @@ public final class PreferenceUtil {
     public ArrayList<CategoryInfo> getLibraryCategoryInfos() {
         String data = mPreferences.getString(LIBRARY_CATEGORIES, null);
         if (data != null) {
-            Gson gson = new Gson();
-            Type collectionType = new TypeToken<ArrayList<CategoryInfo>>() {
+            final Gson gson = new Gson();
+            final Type collectionType = new TypeToken<ArrayList<CategoryInfo>>() {
             }.getType();
 
             try {
                 return gson.fromJson(data, collectionType);
-            } catch (JsonSyntaxException e) {
+            } catch (final JsonSyntaxException e) {
                 e.printStackTrace();
             }
         }
@@ -682,7 +691,7 @@ public final class PreferenceUtil {
     }
 
     public ArrayList<CategoryInfo> getDefaultLibraryCategoryInfos() {
-        ArrayList<CategoryInfo> defaultCategoryInfos = new ArrayList<>(5);
+        final ArrayList<CategoryInfo> defaultCategoryInfos = new ArrayList<>(5);
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.SONGS, true));
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.ALBUMS, true));
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.ARTISTS, true));
@@ -691,24 +700,9 @@ public final class PreferenceUtil {
         return defaultCategoryInfos;
     }
 
-    public final int getThemeStyle() {
-        return getThemeStyleFromPrefValue(mPreferences.getString(THEME_STYLE, "classic"));
-    }
-
-    public static int getThemeStyleFromPrefValue(String themeStylePrefValue) {
-        int theme;
-
-        switch (themeStylePrefValue) {
-            case "rounded":
-                theme = ROUNDED_THEME;
-                break;
-            case "classic":
-            default:
-                theme = CLASSIC_THEME;
-                break;
-        }
-
-        return theme;
+    @NonNull
+    public String getThemeStyle() {
+        return mPreferences.getString(THEME_STYLE, CLASSIC_THEME);
     }
 
     public byte getReplayGainSourceMode() {
@@ -741,11 +735,11 @@ public final class PreferenceUtil {
                 .apply();
     }
 
-    public final String getSAFSDCardUri() {
+    public String getSAFSDCardUri() {
         return mPreferences.getString(SAF_SDCARD_URI, "");
     }
 
-    public final void setSAFSDCardUri(Uri uri) {
+    public void setSAFSDCardUri(@NonNull final Uri uri) {
         mPreferences.edit()
                 .putString(SAF_SDCARD_URI, uri.toString())
                 .apply();

--- a/app/src/main/res/layout/activity_album_detail.xml
+++ b/app/src/main/res/layout/activity_album_detail.xml
@@ -3,12 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="?android:attr/actionBarSize"
     android:orientation="vertical">
 
     <include layout="@layout/status_bar" />
 
     <FrameLayout
+        android:id="@+id/cab_holder"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="@dimen/toolbar_elevation"
@@ -33,12 +34,6 @@
             </com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView>
 
         </androidx.appcompat.widget.Toolbar>
-
-        <ViewStub
-            android:id="@+id/cab_stub_album"
-            android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize" />
-
     </FrameLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/activity_album_detail.xml
+++ b/app/src/main/res/layout/activity_album_detail.xml
@@ -35,7 +35,7 @@
         </androidx.appcompat.widget.Toolbar>
 
         <ViewStub
-            android:id="@+id/cab_stub"
+            android:id="@+id/cab_stub_album"
             android:layout_width="match_parent"
             android:layout_height="?android:attr/actionBarSize" />
 

--- a/app/src/main/res/layout/activity_album_detail.xml
+++ b/app/src/main/res/layout/activity_album_detail.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="?android:attr/actionBarSize"
+    android:layout_height="match_parent"
     android:orientation="vertical">
 
     <include layout="@layout/status_bar" />
@@ -11,7 +11,7 @@
     <FrameLayout
         android:id="@+id/cab_holder"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="?android:attr/actionBarSize"
         android:elevation="@dimen/toolbar_elevation"
         tools:ignore="UnusedAttribute">
 

--- a/app/src/main/res/layout/activity_artist_detail.xml
+++ b/app/src/main/res/layout/activity_artist_detail.xml
@@ -9,8 +9,9 @@
     <include layout="@layout/status_bar" />
 
     <FrameLayout
+        android:id="@+id/cab_holder"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="?android:attr/actionBarSize"
         android:elevation="@dimen/toolbar_elevation"
         tools:ignore="UnusedAttribute">
 
@@ -33,12 +34,6 @@
             </com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView>
 
         </androidx.appcompat.widget.Toolbar>
-
-        <ViewStub
-            android:id="@+id/cab_stub_artist"
-            android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize" />
-
     </FrameLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/activity_artist_detail.xml
+++ b/app/src/main/res/layout/activity_artist_detail.xml
@@ -35,7 +35,7 @@
         </androidx.appcompat.widget.Toolbar>
 
         <ViewStub
-            android:id="@+id/cab_stub"
+            android:id="@+id/cab_stub_artist"
             android:layout_width="match_parent"
             android:layout_height="?android:attr/actionBarSize" />
 

--- a/app/src/main/res/layout/activity_genre_detail.xml
+++ b/app/src/main/res/layout/activity_genre_detail.xml
@@ -47,7 +47,7 @@
                 </androidx.appcompat.widget.Toolbar>
 
                 <ViewStub
-                    android:id="@+id/cab_stub"
+                    android:id="@+id/cab_stub_genre"
                     android:layout_width="match_parent"
                     android:layout_height="?android:attr/actionBarSize" />
 

--- a/app/src/main/res/layout/activity_genre_detail.xml
+++ b/app/src/main/res/layout/activity_genre_detail.xml
@@ -20,8 +20,9 @@
             <include layout="@layout/status_bar" />
 
             <FrameLayout
+                android:id="@+id/cab_holder"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="?android:attr/actionBarSize"
                 android:background="?colorPrimary"
                 android:elevation="@dimen/toolbar_elevation"
                 tools:ignore="UnusedAttribute">
@@ -45,12 +46,6 @@
                     </com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView>
 
                 </androidx.appcompat.widget.Toolbar>
-
-                <ViewStub
-                    android:id="@+id/cab_stub_genre"
-                    android:layout_width="match_parent"
-                    android:layout_height="?android:attr/actionBarSize" />
-
             </FrameLayout>
 
             <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView

--- a/app/src/main/res/layout/activity_playlist_detail.xml
+++ b/app/src/main/res/layout/activity_playlist_detail.xml
@@ -47,7 +47,7 @@
                 </androidx.appcompat.widget.Toolbar>
 
                 <ViewStub
-                    android:id="@+id/cab_stub"
+                    android:id="@+id/cab_stub_playlist"
                     android:layout_width="match_parent"
                     android:layout_height="?android:attr/actionBarSize" />
 

--- a/app/src/main/res/layout/activity_playlist_detail.xml
+++ b/app/src/main/res/layout/activity_playlist_detail.xml
@@ -20,8 +20,9 @@
             <include layout="@layout/status_bar" />
 
             <FrameLayout
+                android:id="@+id/cab_holder"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="?android:attr/actionBarSize"
                 android:background="?colorPrimary"
                 android:elevation="@dimen/toolbar_elevation"
                 tools:ignore="UnusedAttribute">
@@ -41,16 +42,8 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             style="@style/TextAppearance.AppCompat.Widget.ActionBar.Title" />
-
                     </com.poupa.vinylmusicplayer.views.TouchInterceptHorizontalScrollView>
-
                 </androidx.appcompat.widget.Toolbar>
-
-                <ViewStub
-                    android:id="@+id/cab_stub_playlist"
-                    android:layout_width="match_parent"
-                    android:layout_height="?android:attr/actionBarSize" />
-
             </FrameLayout>
 
             <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -32,6 +32,8 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/tab_height"
             android:paddingEnd="8dp"
+            android:paddingLeft="60dp"
+            android:paddingRight="8dp"
             android:paddingStart="60dp" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -14,8 +14,9 @@
         tools:ignore="UnusedAttribute">
 
         <FrameLayout
+            android:id="@+id/cab_holder"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
             app:layout_scrollFlags="scroll|enterAlways">
 
             <androidx.appcompat.widget.Toolbar
@@ -23,14 +24,7 @@
                 style="@style/Toolbar"
                 android:elevation="0dp"
                 tools:ignore="UnusedAttribute">
-
             </androidx.appcompat.widget.Toolbar>
-
-            <ViewStub
-                android:id="@+id/cab_stub_folder"
-                android:layout_width="match_parent"
-                android:layout_height="?android:attr/actionBarSize" />
-
         </FrameLayout>
 
         <com.poupa.vinylmusicplayer.views.BreadCrumbLayout

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -27,7 +27,7 @@
             </androidx.appcompat.widget.Toolbar>
 
             <ViewStub
-                android:id="@+id/cab_stub"
+                android:id="@+id/cab_stub_folder"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/actionBarSize" />
 
@@ -38,8 +38,6 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/tab_height"
             android:paddingEnd="8dp"
-            android:paddingLeft="60dp"
-            android:paddingRight="8dp"
             android:paddingStart="60dp" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -13,8 +13,9 @@
         tools:ignore="UnusedAttribute">
 
         <FrameLayout
+            android:id="@+id/cab_holder_library"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="?android:attr/actionBarSize"
             app:layout_scrollFlags="scroll|enterAlways">
 
             <androidx.appcompat.widget.Toolbar
@@ -22,14 +23,7 @@
                 style="@style/Toolbar"
                 android:elevation="0dp"
                 tools:ignore="UnusedAttribute">
-
             </androidx.appcompat.widget.Toolbar>
-
-            <ViewStub
-                android:id="@+id/cab_stub_library"
-                android:layout_width="match_parent"
-                android:layout_height="?android:attr/actionBarSize" />
-
         </FrameLayout>
 
         <com.google.android.material.tabs.TabLayout

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -13,7 +13,7 @@
         tools:ignore="UnusedAttribute">
 
         <FrameLayout
-            android:id="@+id/cab_holder_library"
+            android:id="@+id/cab_holder"
             android:layout_width="match_parent"
             android:layout_height="?android:attr/actionBarSize"
             app:layout_scrollFlags="scroll|enterAlways">

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -26,7 +26,7 @@
             </androidx.appcompat.widget.Toolbar>
 
             <ViewStub
-                android:id="@+id/cab_stub"
+                android:id="@+id/cab_stub_library"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/actionBarSize" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
-        jcenter()
         google()
         maven { url "https://jitpack.io" }
     }


### PR DESCRIPTION
Attn: Upgraded MaterialCab library drops support for Android below API version 19 (pre-Kitkat). The old MaterialCab is only available via JCenter, which is decommissioned.


- [x] Functional code
- [x] Refactoring (reduce code dupes)
- [x] Todo tags
- [x] Regression tests
